### PR TITLE
Create type guards for drawing types

### DIFF
--- a/drawing/typeguards.ts
+++ b/drawing/typeguards.ts
@@ -1,0 +1,140 @@
+import { PathPrimitive, TextPrimitive, CirclePrimitive, BoxPrimitive, Primitive, NinePointAnchor, Point, SchSymbol, Port, SvgData, Bounds } from "./types"
+
+export function isPathPrimitive(value: any): value is PathPrimitive {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    value.type === "path" &&
+    Array.isArray(value.points) &&
+    value.points.every(isPoint) &&
+    typeof value.color === "string"
+  )
+}
+
+function isPoint(value: any): value is Point {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof value.x === "number" &&
+    typeof value.y === "number"
+  )
+}
+
+export function isTextPrimitive(value: any): value is TextPrimitive {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    value.type === "text" &&
+    typeof value.text === "string" &&
+    typeof value.x === "number" &&
+    typeof value.y === "number" &&
+    isNinePointAnchor(value.anchor)
+  )
+}
+
+export function isCirclePrimitive(value: any): value is CirclePrimitive {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    value.type === "circle" &&
+    typeof value.x === "number" &&
+    typeof value.y === "number" &&
+    typeof value.radius === "number" &&
+    typeof value.fill === "boolean" &&
+    typeof value.color === "string"
+  )
+}
+
+export function isBoxPrimitive(value: any): value is BoxPrimitive {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    value.type === "box" &&
+    typeof value.x === "number" &&
+    typeof value.y === "number" &&
+    typeof value.width === "number" &&
+    typeof value.height === "number" &&
+    isNinePointAnchor(value.anchor)
+  )
+}
+
+export function isPrimitive(value: any): value is Primitive {
+  return (
+    isPathPrimitive(value) ||
+    isTextPrimitive(value) ||
+    isCirclePrimitive(value) ||
+    isBoxPrimitive(value)
+  )
+}
+
+export function isPort(value: any): value is Port {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof value.x === "number" &&
+    typeof value.y === "number" &&
+    Array.isArray(value.labels) &&
+    value.labels.every((label: any) => typeof label === "string")
+  )
+}
+
+export function isSchSymbol(value: any): value is SchSymbol {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray(value.primitives) &&
+    value.primitives.every(isPrimitive) &&
+    isPoint(value.center) &&
+    Array.isArray(value.ports) &&
+    value.ports.every(isPort) &&
+    typeof value.size === "object" &&
+    value.size !== null &&
+    typeof value.size.width === "number" &&
+    typeof value.size.height === "number"
+  )
+}
+
+export function isBounds(value: any): value is Bounds {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof value.minX === "number" &&
+    typeof value.maxX === "number" &&
+    typeof value.minY === "number" &&
+    typeof value.maxY === "number" &&
+    typeof value.width === "number" &&
+    typeof value.height === "number" &&
+    typeof value.centerX === "number" &&
+    typeof value.centerY === "number"
+  )
+}
+
+export function isSvgData(value: any): value is SvgData {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof value.paths === "object" &&
+    Object.values(value.paths).every(isPathPrimitive) &&
+    typeof value.texts === "object" &&
+    Object.values(value.texts).every(isTextPrimitive) &&
+    typeof value.refblocks === "object" &&
+    Object.values(value.refblocks).every(isPoint) &&
+    isBounds(value.bounds) &&
+    typeof value.circles === "object" &&
+    Object.values(value.circles).every(isCirclePrimitive)
+  )
+}
+
+export function isNinePointAnchor(value: any): value is NinePointAnchor {
+  return [
+    "top_left",
+    "top_right",
+    "bottom_left",
+    "bottom_right",
+    "center",
+    "middle_top",
+    "middle_bottom",
+    "middle_left",
+    "middle_right"
+  ].includes(value)
+}

--- a/drawing/typeguards.ts
+++ b/drawing/typeguards.ts
@@ -1,4 +1,16 @@
-import { PathPrimitive, TextPrimitive, CirclePrimitive, BoxPrimitive, Primitive, NinePointAnchor, Point, SchSymbol, Port, SvgData, Bounds } from "./types"
+import {
+  PathPrimitive,
+  TextPrimitive,
+  CirclePrimitive,
+  BoxPrimitive,
+  Primitive,
+  NinePointAnchor,
+  Point,
+  SchSymbol,
+  Port,
+  SvgData,
+  Bounds,
+} from "./types"
 
 // Basic types
 function isPoint(value: any): value is Point {
@@ -20,7 +32,7 @@ export function isNinePointAnchor(value: any): value is NinePointAnchor {
     "middle_top",
     "middle_bottom",
     "middle_left",
-    "middle_right"
+    "middle_right",
   ].includes(value)
 }
 

--- a/drawing/typeguards.ts
+++ b/drawing/typeguards.ts
@@ -1,5 +1,30 @@
 import { PathPrimitive, TextPrimitive, CirclePrimitive, BoxPrimitive, Primitive, NinePointAnchor, Point, SchSymbol, Port, SvgData, Bounds } from "./types"
 
+// Basic types
+function isPoint(value: any): value is Point {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof value.x === "number" &&
+    typeof value.y === "number"
+  )
+}
+
+export function isNinePointAnchor(value: any): value is NinePointAnchor {
+  return [
+    "top_left",
+    "top_right",
+    "bottom_left",
+    "bottom_right",
+    "center",
+    "middle_top",
+    "middle_bottom",
+    "middle_left",
+    "middle_right"
+  ].includes(value)
+}
+
+// Primitive types
 export function isPathPrimitive(value: any): value is PathPrimitive {
   return (
     typeof value === "object" &&
@@ -8,15 +33,6 @@ export function isPathPrimitive(value: any): value is PathPrimitive {
     Array.isArray(value.points) &&
     value.points.every(isPoint) &&
     typeof value.color === "string"
-  )
-}
-
-function isPoint(value: any): value is Point {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof value.x === "number" &&
-    typeof value.y === "number"
   )
 }
 
@@ -67,6 +83,7 @@ export function isPrimitive(value: any): value is Primitive {
   )
 }
 
+// Complex types
 export function isPort(value: any): value is Port {
   return (
     typeof value === "object" &&
@@ -123,18 +140,4 @@ export function isSvgData(value: any): value is SvgData {
     typeof value.circles === "object" &&
     Object.values(value.circles).every(isCirclePrimitive)
   )
-}
-
-export function isNinePointAnchor(value: any): value is NinePointAnchor {
-  return [
-    "top_left",
-    "top_right",
-    "bottom_left",
-    "bottom_right",
-    "center",
-    "middle_top",
-    "middle_bottom",
-    "middle_left",
-    "middle_right"
-  ].includes(value)
 }


### PR DESCRIPTION
I am introducing these type guards so that when performing operations on a symbol, I can easily reassure TS that the objects are valid. An example:

```ts

// more code....

const { 6: letter, 2: underline, ...rest } = dc_ammeter_horz.primitives

if (isPathPrimitive(underline)) {
  underline.points.map((p) => {
    p.y += 0.05
  })
}

if (isTextPrimitive(letter)) {
  letter.y += 0.025
}

const rotatedSymbol = rotateSymbol({
  ...dc_ammeter_horz,
  primitives: Object.values(rest).filter(isPrimitive),
})

export default {
  ...rotatedSymbol,
  primitives: [...rotatedSymbol.primitives, letter, underline],
}
```