### PR TITLE
added schematic symbols count, github stars badge

### DIFF
--- a/scripts/lib/generate-web-page.ts
+++ b/scripts/lib/generate-web-page.ts
@@ -5,6 +5,8 @@ export function generateWebPage(): string {
   const symbolEntries = Object.entries(symbols).sort((a, b) =>
     a[0].localeCompare(b[0]),
   )
+  const svgCount = symbolEntries.length
+  const unqieSymbolCount = svgCount / 2
 
   const svgGrid = symbolEntries
     .map(([name, symbol]) => {
@@ -38,6 +40,30 @@ export function generateWebPage(): string {
           margin: 0;
           padding: 20px;
         }
+        .header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          margin-bottom: 20px;
+        }
+        .header h1 {
+          margin: 0;
+        }
+        .symbol-count {
+          font-size: 20px;
+          margin-left: 15px;
+          color: #555;
+          margin-bottom: 0px;
+        }
+        .github-stars {
+          margin-left: auto;
+          display: flex;
+          align-items: center;
+        }
+
+        .github-stars a img {
+          height: 24px;
+        }
         .grid {
           display: grid;
           grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -47,7 +73,6 @@ export function generateWebPage(): string {
           border: 1px solid #ccc;
           padding: 10px;
           text-align: center;
-          
         }
         svg {
           max-width: 100%;
@@ -56,13 +81,20 @@ export function generateWebPage(): string {
       </style>
     </head>
     <body>
-      <h1>Schematic Symbols</h1>
+      <div class="header">
+        <h1>Schematic Symbols</h1>
+        <span class="symbol-count">(${unqieSymbolCount})</span>
+        <div class="github-stars">
+          <a href="https://github.com/tscircuit/schematic-symbols" target="_blank">
+            <img alt="GitHub stars" src="https://img.shields.io/github/stars/tscircuit/schematic-symbols?style=social">
+          </a>
+        </div>
+      </div>
       <div class="grid">
         ${svgGrid}
       </div>
     </body>
     </html>
   `
-
   return html
 }


### PR DESCRIPTION
fixes #164 

Changes:
- Adds a count of unique symbols (horizontal and vertical together counted as one )available to use in schematic symbols repo 
- Added a github stars badge to the header

Screenshot:
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/a670488c-64f6-4056-b5d0-e244a6c45cc2">


let me know if i need to make any more changes !!


cc: @seveibar 