### PR TITLE
Fix Darlington pair transistor pin order

### DIFF
--- a/symbols/darlington_pair_transistor_down.ts
+++ b/symbols/darlington_pair_transistor_down.ts
@@ -3,8 +3,8 @@ import svgJson from "assets/generated/darlington_pair_transistor.json"
 
 export default modifySymbol(svgJson)
   .rotateRightFacingSymbol("down")
-  .labelPort("right1", ["1"])
-  .labelPort("right2", ["2"])
+  .labelPort("right2", ["1"])
+  .labelPort("right1", ["2"])
   .labelPort("right3", ["3"])
   .changeTextAnchor("{VAL}", "middle_left", { x: 0.8, y: -0.15 })
   .changeTextAnchor("{REF}", "middle_left", { x: 0, y: 0.15 })

--- a/symbols/darlington_pair_transistor_horz.ts
+++ b/symbols/darlington_pair_transistor_horz.ts
@@ -3,9 +3,9 @@ import svgJson from "assets/generated/darlington_pair_transistor.json"
 
 export default modifySymbol(svgJson)
   .rotateRightFacingSymbol("right")
-  .labelPort("right1", ["1"])
-  .labelPort("right2", ["2"])
-  .labelPort("right3", ["3"])
+  .labelPort("right2", ["1"])
+  .labelPort("right3", ["2"])
+  .labelPort("right1", ["3"])
   .changeTextAnchor("{VAL}", "middle_right")
   .changeTextAnchor("{REF}", "middle_right")
   .build()

--- a/symbols/darlington_pair_transistor_left.ts
+++ b/symbols/darlington_pair_transistor_left.ts
@@ -3,8 +3,8 @@ import svgJson from "assets/generated/darlington_pair_transistor.json"
 
 export default modifySymbol(svgJson)
   .rotateRightFacingSymbol("left")
-  .labelPort("right1", ["1"])
-  .labelPort("right2", ["2"])
+  .labelPort("right2", ["1"])
+  .labelPort("right1", ["2"])
   .labelPort("right3", ["3"])
   .changeTextAnchor("{VAL}", "middle_left", { x: 0, y: -0.8 })
   .changeTextAnchor("{REF}", "middle_left", { x: 0, y: 0.8 })

--- a/symbols/darlington_pair_transistor_right.ts
+++ b/symbols/darlington_pair_transistor_right.ts
@@ -3,9 +3,9 @@ import svgJson from "assets/generated/darlington_pair_transistor.json"
 
 export default modifySymbol(svgJson)
   .rotateRightFacingSymbol("right")
-  .labelPort("right1", ["1"])
-  .labelPort("right2", ["2"])
-  .labelPort("right3", ["3"])
+  .labelPort("right2", ["1"])
+  .labelPort("right3", ["2"])
+  .labelPort("right1", ["3"])
   .changeTextAnchor("{VAL}", "middle_right")
   .changeTextAnchor("{REF}", "middle_right")
   .build()

--- a/symbols/darlington_pair_transistor_up.ts
+++ b/symbols/darlington_pair_transistor_up.ts
@@ -3,8 +3,8 @@ import svgJson from "assets/generated/darlington_pair_transistor.json"
 
 export default modifySymbol(svgJson)
   .rotateRightFacingSymbol("up")
-  .labelPort("right1", ["1"])
-  .labelPort("right2", ["2"])
+  .labelPort("right2", ["1"])
+  .labelPort("right1", ["2"])
   .labelPort("right3", ["3"])
   .changeTextAnchor("{VAL}", "middle_left", { x: 0, y: -0.15 })
   .changeTextAnchor("{REF}", "middle_left", { x: 0.8, y: 0.15 })

--- a/symbols/darlington_pair_transistor_vert.ts
+++ b/symbols/darlington_pair_transistor_vert.ts
@@ -3,8 +3,8 @@ import svgJson from "assets/generated/darlington_pair_transistor.json"
 
 export default modifySymbol(svgJson)
   .rotateRightFacingSymbol("up")
-  .labelPort("right1", ["1"])
-  .labelPort("right2", ["2"])
+  .labelPort("right2", ["1"])
+  .labelPort("right1", ["2"])
   .labelPort("right3", ["3"])
   .changeTextAnchor("{VAL}", "middle_left", { x: 0, y: -0.15 })
   .changeTextAnchor("{REF}", "middle_left", { x: 0.8, y: 0.15 })

--- a/tests/__snapshots__/darlington_pair_transistor_down.snap.svg
+++ b/tests/__snapshots__/darlington_pair_transistor_down.snap.svg
@@ -15,12 +15,12 @@
     <text x="2.3776062" y="1.323700944" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="2.3651061999999996" y="1.311200944" width="0.025" height="0.025" fill="blue" />
     <circle cx="1.980037" cy="1.6355001440000003" r="0.29977763" fill="none" stroke="black" stroke-width="0.02" />
 
-    <rect x="1.5262342" y="1.7920246440000005" width="0.05" height="0.05" fill="red" />
-    <text x="1.5112341999999999" y="1.9070246440000005" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
-  
-    
     <rect x="1.9885926999999999" y="1.1618705440000003" width="0.05" height="0.05" fill="red" />
-    <text x="1.9735926999999998" y="1.2768705440000003" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+    <text x="1.9735926999999998" y="1.2768705440000003" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+
+
+    <rect x="1.5262342" y="1.7920246440000005" width="0.05" height="0.05" fill="red" />
+    <text x="1.5112341999999999" y="1.9070246440000005" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
     
     <rect x="2.3509783" y="1.792030944" width="0.05" height="0.05" fill="red" />

--- a/tests/__snapshots__/darlington_pair_transistor_horz.snap.svg
+++ b/tests/__snapshots__/darlington_pair_transistor_horz.snap.svg
@@ -15,16 +15,16 @@
     <text x="1.8845380145" y="1.1387692295000003" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="1.8720380145" y="1.1262692295000003" width="0.025" height="0.025" fill="blue" />
     <circle cx="2.0463372145000003" cy="1.5363384295000002" r="0.29977763" fill="none" stroke="black" stroke-width="0.02" />
 
-    <rect x="2.2028617145000005" y="1.9401412295000005" width="0.05" height="0.05" fill="red" />
-    <text x="2.1878617145000003" y="2.0551412295" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
-  
-    
     <rect x="1.5727076145000003" y="1.4777827295000003" width="0.05" height="0.05" fill="red" />
-    <text x="1.5577076145000002" y="1.5927827295000003" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
-  
-    
+    <text x="1.5577076145000002" y="1.5927827295000003" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+
+
     <rect x="2.2028680145" y="1.1153971295000003" width="0.05" height="0.05" fill="red" />
-    <text x="2.1878680145" y="1.2303971295000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+    <text x="2.1878680145" y="1.2303971295000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+
+
+    <rect x="2.2028617145000005" y="1.9401412295000005" width="0.05" height="0.05" fill="red" />
+    <text x="2.1878617145000003" y="2.0551412295" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 1.9636062500000002 1.5277691795000004 L 1.9886062500000001 1.5527691795000003 L 1.9636062500000002 1.5777691795000002 L 1.9386062500000003 1.5527691795000003 Z" fill="green" />
 <text x="1.5894902350000002" y="-1.9617564295000003" style="font: 0.05px monospace; fill: #833;">0.75 x 0.82</text>

--- a/tests/__snapshots__/darlington_pair_transistor_left.snap.svg
+++ b/tests/__snapshots__/darlington_pair_transistor_left.snap.svg
@@ -15,12 +15,12 @@
     <text x="2.0426744855" y="1.1667691295000004" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="2.0301744855" y="1.1542691295000005" width="0.025" height="0.025" fill="blue" />
     <circle cx="1.8808752855000002" cy="1.5691999295000005" r="0.29977763" fill="none" stroke="black" stroke-width="0.02" />
 
-    <rect x="1.6743507854999997" y="1.1153971295000005" width="0.05" height="0.05" fill="red" />
-    <text x="1.6593507854999996" y="1.2303971295000005" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
-  
-    
     <rect x="2.3045048855" y="1.5777556295000006" width="0.05" height="0.05" fill="red" />
-    <text x="2.2895048855" y="1.6927556295000006" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+    <text x="2.2895048855" y="1.6927556295000006" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+
+
+    <rect x="1.6743507854999997" y="1.1153971295000005" width="0.05" height="0.05" fill="red" />
+    <text x="1.6593507854999996" y="1.2303971295000005" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
     
     <rect x="1.6743444855000007" y="1.9401412295000007" width="0.05" height="0.05" fill="red" />

--- a/tests/__snapshots__/darlington_pair_transistor_right.snap.svg
+++ b/tests/__snapshots__/darlington_pair_transistor_right.snap.svg
@@ -15,16 +15,16 @@
     <text x="1.8845380145" y="1.1387692295000003" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="1.8720380145" y="1.1262692295000003" width="0.025" height="0.025" fill="blue" />
     <circle cx="2.0463372145000003" cy="1.5363384295000002" r="0.29977763" fill="none" stroke="black" stroke-width="0.02" />
 
-    <rect x="2.2028617145000005" y="1.9401412295000005" width="0.05" height="0.05" fill="red" />
-    <text x="2.1878617145000003" y="2.0551412295" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
-  
-    
     <rect x="1.5727076145000003" y="1.4777827295000003" width="0.05" height="0.05" fill="red" />
-    <text x="1.5577076145000002" y="1.5927827295000003" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
-  
-    
+    <text x="1.5577076145000002" y="1.5927827295000003" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+
+
     <rect x="2.2028680145" y="1.1153971295000003" width="0.05" height="0.05" fill="red" />
-    <text x="2.1878680145" y="1.2303971295000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+    <text x="2.1878680145" y="1.2303971295000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+
+
+    <rect x="2.2028617145000005" y="1.9401412295000005" width="0.05" height="0.05" fill="red" />
+    <text x="2.1878617145000003" y="2.0551412295" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 1.9636062500000002 1.5277691795000004 L 1.9886062500000001 1.5527691795000003 L 1.9636062500000002 1.5777691795000002 L 1.9386062500000003 1.5527691795000003 Z" fill="green" />
 <text x="1.5894902350000002" y="-1.9617564295000003" style="font: 0.05px monospace; fill: #833;">0.75 x 0.82</text>

--- a/tests/__snapshots__/darlington_pair_transistor_up.snap.svg
+++ b/tests/__snapshots__/darlington_pair_transistor_up.snap.svg
@@ -15,12 +15,12 @@
     <text x="2.3496063000000005" y="1.4818374150000007" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="2.3371063000000003" y="1.4693374150000007" width="0.025" height="0.025" fill="blue" />
     <circle cx="1.9471755000000002" cy="1.4700382150000002" r="0.29977763" fill="none" stroke="black" stroke-width="0.02" />
 
-    <rect x="2.3509783000000004" y="1.2635137150000002" width="0.05" height="0.05" fill="red" />
-    <text x="2.3359783000000003" y="1.3785137150000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
-  
-    
     <rect x="1.8886198" y="1.8936678150000004" width="0.05" height="0.05" fill="red" />
-    <text x="1.8736198" y="2.0086678150000004" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+    <text x="1.8736198" y="2.0086678150000004" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+
+
+    <rect x="2.3509783000000004" y="1.2635137150000002" width="0.05" height="0.05" fill="red" />
+    <text x="2.3359783000000003" y="1.3785137150000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
     
     <rect x="1.5262342000000002" y="1.2635074150000007" width="0.05" height="0.05" fill="red" />

--- a/tests/__snapshots__/darlington_pair_transistor_vert.snap.svg
+++ b/tests/__snapshots__/darlington_pair_transistor_vert.snap.svg
@@ -15,12 +15,12 @@
     <text x="2.3496063000000005" y="1.4818374150000007" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="2.3371063000000003" y="1.4693374150000007" width="0.025" height="0.025" fill="blue" />
     <circle cx="1.9471755000000002" cy="1.4700382150000002" r="0.29977763" fill="none" stroke="black" stroke-width="0.02" />
 
-    <rect x="2.3509783000000004" y="1.2635137150000002" width="0.05" height="0.05" fill="red" />
-    <text x="2.3359783000000003" y="1.3785137150000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
-  
-    
     <rect x="1.8886198" y="1.8936678150000004" width="0.05" height="0.05" fill="red" />
-    <text x="1.8736198" y="2.0086678150000004" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+    <text x="1.8736198" y="2.0086678150000004" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+
+
+    <rect x="2.3509783000000004" y="1.2635137150000002" width="0.05" height="0.05" fill="red" />
+    <text x="2.3359783000000003" y="1.3785137150000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
     
     <rect x="1.5262342000000002" y="1.2635074150000007" width="0.05" height="0.05" fill="red" />


### PR DESCRIPTION
## Summary
- fix darlington pair transistor pin numbering to increment counter-clockwise
- update Darlington pair transistor snapshots

## Testing
- ⚠️ `bun run format` (missing biome executable)
- ⚠️ `bun run build` (missing make-vfs dependency)
- ⚠️ `bun test --update-snapshots` (missing bun-match-svg package)


------
https://chatgpt.com/codex/tasks/task_e_68a313e8c9948328bba34d5798ebefeb