### PR TITLE
Replace console.log with structured server logging

### DIFF
--- a/dev-server.ts
+++ b/dev-server.ts
@@ -1,8 +1,9 @@
 import { getSvg } from "drawing/getSvg"
 import symbols from "./generated/symbols-index"
 import { generateWebPage } from "./scripts/lib/generate-web-page"
+import { logger } from "./logger"
 
-console.log(`Serving on http://localhost:3077`)
+logger.info("Serving", { url: "http://localhost:3077" })
 Bun.serve({
   port: 3077,
   async fetch(req) {

--- a/drawing/svgPathToPoints.ts
+++ b/drawing/svgPathToPoints.ts
@@ -1,6 +1,7 @@
 import type { Point } from "./types"
 import { approximateArc } from "./arc"
 import { approximateBezier } from "./cubicBezierCurveArc"
+import { logger } from "../logger"
 
 export function svgPathToPoints(pathString: string): Point[] {
   const points: Point[] = []
@@ -77,7 +78,7 @@ export function svgPathToPoints(pathString: string): Point[] {
         break
       // Add cases for other commands (S, T) if needed
       default:
-        console.warn(`Unsupported SVG command: ${type}`)
+        logger.warn("Unsupported SVG command", { type })
     }
 
     // Handle relative commands

--- a/logger.ts
+++ b/logger.ts
@@ -1,0 +1,23 @@
+export type LogLevel = "info" | "warn" | "error"
+
+interface LogMeta {
+  [key: string]: unknown
+}
+
+function log(level: LogLevel, message: string, meta: LogMeta = {}): void {
+  const entry = { level, message, time: new Date().toISOString(), ...meta }
+  const line = JSON.stringify(entry)
+  if (level === "error") {
+    console.error(line)
+  } else if (level === "warn") {
+    console.warn(line)
+  } else {
+    console.log(line)
+  }
+}
+
+export const logger = {
+  info: (message: string, meta?: LogMeta) => log("info", message, meta),
+  warn: (message: string, meta?: LogMeta) => log("warn", message, meta),
+  error: (message: string, meta?: LogMeta) => log("error", message, meta),
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -3,6 +3,7 @@ import { generateWebPage } from "./lib/generate-web-page"
 import fs from "fs"
 import symbols from "generated/symbols-index"
 import path from "path/posix"
+import { logger } from "../logger"
 
 const distDir = path.join(process.cwd(), "public")
 
@@ -30,4 +31,4 @@ for (const symbolName in symbols) {
   )
 }
 
-console.log("Static HTML file generated at public/index.html")
+logger.info("Static HTML file generated", { path: "public/index.html" })

--- a/scripts/generate-symbol-from-asset-svg.ts
+++ b/scripts/generate-symbol-from-asset-svg.ts
@@ -2,6 +2,7 @@ import { processSvg } from "./lib/svg-generation-fns/svg-generation-fns"
 import fs from "fs"
 import path from "path"
 import prompts from "prompts"
+import { logger } from "../logger"
 
 async function main() {
   const symbolsDir = path.join(import.meta.dir, "..", "assets", "symbols")
@@ -44,11 +45,11 @@ async function main() {
         directionResponse.direction,
       )
     } else {
-      console.log("No orientation selected. Exiting.")
+      logger.warn("No orientation selected. Exiting.")
     }
   } else {
-    console.log("No file selected. Exiting.")
+    logger.warn("No file selected. Exiting.")
   }
 }
 
-main().catch(console.error)
+main().catch((err) => logger.error("Error generating symbol", { error: err }))

--- a/scripts/round-numbers.ts
+++ b/scripts/round-numbers.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { readdir, readFile, writeFile } from "fs/promises"
 import { join } from "path"
+import { logger } from "../logger"
 
 function roundToTwoDecimals(num: number): number {
   return Math.round(num * 100) / 100
@@ -37,12 +38,12 @@ async function processJsonFiles(dir: string) {
         await writeFile(filePath, JSON.stringify(roundedData, null, 2))
         processedCount++
       } catch (error) {
-        console.error(`Error processing ${file}:`, error)
+        logger.error("Error processing file", { file, error })
       }
     }
   }
 
-  console.log(`Processed ${processedCount} JSON files in ${dir}`)
+  logger.info("Processed JSON files", { count: processedCount, dir })
 }
 
 // Process assets/generated directory

--- a/scripts/validate-snapshots.ts
+++ b/scripts/validate-snapshots.ts
@@ -1,6 +1,7 @@
 import fs from "fs"
 import path from "path"
 import symbols from "../generated/symbols-index"
+import { logger } from "../logger"
 
 function validateSnapshots() {
   const missingSnapshots: string[] = []
@@ -17,12 +18,11 @@ function validateSnapshots() {
   }
 
   if (missingSnapshots.length > 0) {
-    console.error("Error: Snapshots missing for the following symbols:")
-    missingSnapshots.forEach((symbol) => console.error(`- ${symbol}`))
+    logger.error("Snapshots missing", { symbols: missingSnapshots })
     process.exit(1)
   }
 
-  console.log("All symbol snapshots are present.")
+  logger.info("All symbol snapshots are present")
 }
 
 validateSnapshots()


### PR DESCRIPTION
## Summary
- add JSON-formatted logger with info/warn/error helpers
- replace console logging in server and scripts with structured logger

## Testing
- `bun run format`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68ae984b74c083288981c6d9c01bacb0