### PR TITLE
chore: increase symbol post-processing precision

### DIFF
--- a/scripts/round-numbers.ts
+++ b/scripts/round-numbers.ts
@@ -2,13 +2,13 @@
 import { readdir, readFile, writeFile } from "fs/promises"
 import { join } from "path"
 
-function roundToTwoDecimals(num: number): number {
-  return Math.round(num * 100) / 100
+function roundToThreeDecimals(num: number): number {
+  return Math.round(num * 1000) / 1000
 }
 
 function roundNumbersInObject(obj: any): any {
   if (typeof obj === "number") {
-    return roundToTwoDecimals(obj)
+    return roundToThreeDecimals(obj)
   }
   if (Array.isArray(obj)) {
     return obj.map(roundNumbersInObject)


### PR DESCRIPTION
## Summary
- round symbol JSON values to three decimals instead of two

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests`
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68bf4eb95008832ea544e9e3e5cf7d6d