### PR TITLE
Resize VCC symbol to match rail dimensions

### DIFF
--- a/symbols/vcc_down.ts
+++ b/symbols/vcc_down.ts
@@ -1,8 +1,11 @@
 import svgJson from "../assets/generated/vcc.json"
 import { modifySymbol } from "drawing/modify-symbol/modify-symbol"
+import { resizeSymbol } from "drawing/resizeSymbol"
 
-export default modifySymbol(svgJson)
+const symbol = modifySymbol(svgJson)
   .rotateRightFacingSymbol("down")
   .labelPort("left1", ["1"])
   .changeTextAnchor("{REF}", "middle_top")
   .build()
+
+export default resizeSymbol(symbol, { width: 0.24, height: 0.23 })

--- a/symbols/vcc_left.ts
+++ b/symbols/vcc_left.ts
@@ -1,8 +1,11 @@
 import svgJson from "../assets/generated/vcc.json"
 import { modifySymbol } from "drawing/modify-symbol/modify-symbol"
+import { resizeSymbol } from "drawing/resizeSymbol"
 
-export default modifySymbol(svgJson)
+const symbol = modifySymbol(svgJson)
   .rotateRightFacingSymbol("left")
   .labelPort("left1", ["1"])
   .changeTextAnchor("{REF}", "middle_right")
   .build()
+
+export default resizeSymbol(symbol, { width: 0.23, height: 0.24 })

--- a/symbols/vcc_right.ts
+++ b/symbols/vcc_right.ts
@@ -1,8 +1,11 @@
 import svgJson from "../assets/generated/vcc.json"
 import { modifySymbol } from "drawing/modify-symbol/modify-symbol"
+import { resizeSymbol } from "drawing/resizeSymbol"
 
-export default modifySymbol(svgJson)
+const symbol = modifySymbol(svgJson)
   .rotateRightFacingSymbol("right")
   .labelPort("left1", ["1"])
   .changeTextAnchor("{REF}", "middle_left")
   .build()
+
+export default resizeSymbol(symbol, { width: 0.23, height: 0.24 })

--- a/symbols/vcc_up.ts
+++ b/symbols/vcc_up.ts
@@ -1,8 +1,11 @@
 import svgJson from "../assets/generated/vcc.json"
 import { modifySymbol } from "drawing/modify-symbol/modify-symbol"
+import { resizeSymbol } from "drawing/resizeSymbol"
 
-export default modifySymbol(svgJson)
+const symbol = modifySymbol(svgJson)
   .rotateRightFacingSymbol("up")
   .labelPort("left1", ["1"])
   .changeTextAnchor("{REF}", "middle_bottom")
   .build()
+
+export default resizeSymbol(symbol, { width: 0.24, height: 0.23 })

--- a/tests/__snapshots__/vcc_down.snap.svg
+++ b/tests/__snapshots__/vcc_down.snap.svg
@@ -1,11 +1,11 @@
-<svg width="150" height="150" viewBox="-0.108 -0.282 0.216 0.564" xmlns="http://www.w3.org/2000/svg"><path d="M1.1634144591899856e-17,0.19 L0.09,-5.5109105961630896e-18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M1.1634144591899856e-17,0.19 L-0.09,5.5109105961630896e-18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M1.1634144591899856e-17,0.19 L-1.3471114790620885e-17,-0.22" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="1.5308084989341915e-17" y="0.25" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.012499999999999985" y="0.2375" width="0.025" height="0.025" fill="blue" />
+<svg width="150" height="150" viewBox="-0.144 -0.138 0.288 0.276" xmlns="http://www.w3.org/2000/svg"><path d="M1.5512192789199808e-17,0.09297872340425532 L0.12,-2.696828589611725e-18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M1.5512192789199808e-17,0.09297872340425532 L-0.12,2.696828589611725e-18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M1.5512192789199808e-17,0.09297872340425532 L-1.7961486387494512e-17,-0.10765957446808512" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="2.041077998578922e-17" y="0.1223404255319149" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.01249999999999998" y="0.1098404255319149" width="0.025" height="0.025" fill="blue" />
 
-    <rect x="-0.025000000000000015" y="-0.255" width="0.05" height="0.05" fill="red" />
-    <text x="-0.040000000000000015" y="-0.13999999999999999" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+    <rect x="-0.02500000000000002" y="-0.1375531914893617" width="0.05" height="0.05" fill="red" />
+    <text x="-0.04000000000000002" y="-0.02255319148936171" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.09" y="-0.235" style="font: 0.05px monospace; fill: #833;">0.18 x 0.47</text>
-<text x="-0.09" y="-0.235" style="font: 0.05px monospace; fill: #833;">0.18 x 0.47</text></svg>
+<text x="-0.12" y="-0.115" style="font: 0.05px monospace; fill: #833;">0.24 x 0.23</text>
+<text x="-0.12" y="-0.115" style="font: 0.05px monospace; fill: #833;">0.24 x 0.23</text></svg>

--- a/tests/__snapshots__/vcc_left.snap.svg
+++ b/tests/__snapshots__/vcc_left.snap.svg
@@ -1,11 +1,11 @@
-<svg width="150" height="150" viewBox="-0.282 -0.108 0.564 0.216" xmlns="http://www.w3.org/2000/svg"><path d="M-0.19,2.3268289183799712e-17 L1.1021821192326179e-17,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-0.19,2.3268289183799712e-17 L-1.1021821192326179e-17,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-0.19,2.3268289183799712e-17 L0.22,-2.694222958124177e-17" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="-0.25" y="3.061616997868383e-17" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.2625" y="-0.01249999999999997" width="0.025" height="0.025" fill="blue" />
+<svg width="150" height="150" viewBox="-0.138 -0.144 0.276 0.288" xmlns="http://www.w3.org/2000/svg"><path d="M-0.09297872340425532,3.1024385578399616e-17 L5.39365717922345e-18,0.12" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09297872340425532,3.1024385578399616e-17 L-5.39365717922345e-18,-0.12" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09297872340425532,3.1024385578399616e-17 L0.10765957446808512,-3.5922972774989024e-17" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="-0.1223404255319149" y="4.082155997157844e-17" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.13484042553191491" y="-0.012499999999999959" width="0.025" height="0.025" fill="blue" />
 
-    <rect x="0.20500000000000002" y="-0.02500000000000003" width="0.05" height="0.05" fill="red" />
-    <text x="0.19" y="0.08999999999999997" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+    <rect x="0.08755319148936172" y="-0.02500000000000004" width="0.05" height="0.05" fill="red" />
+    <text x="0.0725531914893617" y="0.08999999999999997" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.235" y="-0.09" style="font: 0.05px monospace; fill: #833;">0.47 x 0.18</text>
-<text x="-0.235" y="-0.09" style="font: 0.05px monospace; fill: #833;">0.47 x 0.18</text></svg>
+<text x="-0.115" y="-0.12" style="font: 0.05px monospace; fill: #833;">0.23 x 0.24</text>
+<text x="-0.115" y="-0.12" style="font: 0.05px monospace; fill: #833;">0.23 x 0.24</text></svg>

--- a/tests/__snapshots__/vcc_right.snap.svg
+++ b/tests/__snapshots__/vcc_right.snap.svg
@@ -1,11 +1,11 @@
-<svg width="150" height="150" viewBox="-0.282 -0.108 0.564 0.216" xmlns="http://www.w3.org/2000/svg"><path d="M0.19,0 L0,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M0.19,0 L0,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M0.19,0 L-0.22,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.25" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.2375" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+<svg width="150" height="150" viewBox="-0.138 -0.144 0.276 0.288" xmlns="http://www.w3.org/2000/svg"><path d="M0.09297872340425532,0 L0,-0.12" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09297872340425532,0 L0,0.12" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09297872340425532,0 L-0.10765957446808512,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="0.1223404255319149" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.1098404255319149" y="-0.0125" width="0.025" height="0.025" fill="blue" />
 
-    <rect x="-0.255" y="-0.025" width="0.05" height="0.05" fill="red" />
-    <text x="-0.27" y="0.09" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+    <rect x="-0.1375531914893617" y="-0.025" width="0.05" height="0.05" fill="red" />
+    <text x="-0.15255319148936172" y="0.09" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.235" y="-0.09" style="font: 0.05px monospace; fill: #833;">0.47 x 0.18</text>
-<text x="-0.235" y="-0.09" style="font: 0.05px monospace; fill: #833;">0.47 x 0.18</text></svg>
+<text x="-0.115" y="-0.12" style="font: 0.05px monospace; fill: #833;">0.23 x 0.24</text>
+<text x="-0.115" y="-0.12" style="font: 0.05px monospace; fill: #833;">0.23 x 0.24</text></svg>

--- a/tests/__snapshots__/vcc_up.snap.svg
+++ b/tests/__snapshots__/vcc_up.snap.svg
@@ -1,11 +1,11 @@
-<svg width="150" height="150" viewBox="-0.108 -0.282 0.216 0.564" xmlns="http://www.w3.org/2000/svg"><path d="M1.1634144591899856e-17,-0.19 L-0.09,-5.5109105961630896e-18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M1.1634144591899856e-17,-0.19 L0.09,5.5109105961630896e-18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M1.1634144591899856e-17,-0.19 L-1.3471114790620885e-17,0.22" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="1.5308084989341915e-17" y="-0.25" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.012499999999999985" y="-0.2625" width="0.025" height="0.025" fill="blue" />
+<svg width="150" height="150" viewBox="-0.144 -0.138 0.288 0.276" xmlns="http://www.w3.org/2000/svg"><path d="M1.5512192789199808e-17,-0.09297872340425532 L-0.12,-2.696828589611725e-18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M1.5512192789199808e-17,-0.09297872340425532 L0.12,2.696828589611725e-18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M1.5512192789199808e-17,-0.09297872340425532 L-1.7961486387494512e-17,0.10765957446808512" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="2.041077998578922e-17" y="-0.1223404255319149" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.01249999999999998" y="-0.13484042553191491" width="0.025" height="0.025" fill="blue" />
 
-    <rect x="-0.025000000000000015" y="0.20500000000000002" width="0.05" height="0.05" fill="red" />
-    <text x="-0.040000000000000015" y="0.32" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+    <rect x="-0.02500000000000002" y="0.08755319148936172" width="0.05" height="0.05" fill="red" />
+    <text x="-0.04000000000000002" y="0.2025531914893617" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.09" y="-0.235" style="font: 0.05px monospace; fill: #833;">0.18 x 0.47</text>
-<text x="-0.09" y="-0.235" style="font: 0.05px monospace; fill: #833;">0.18 x 0.47</text></svg>
+<text x="-0.12" y="-0.115" style="font: 0.05px monospace; fill: #833;">0.24 x 0.23</text>
+<text x="-0.12" y="-0.115" style="font: 0.05px monospace; fill: #833;">0.24 x 0.23</text></svg>


### PR DESCRIPTION
## Summary
- shrink VCC symbol using `resizeSymbol` so all orientations match rail symbol size
- update SVG snapshots

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/snapshot-svg.test.ts`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68bf679c0660832ea1c8331f8c94bcce