### PR TITLE
Move capacitor text closer to center axis

### DIFF
--- a/symbols/capacitor_down.ts
+++ b/symbols/capacitor_down.ts
@@ -10,13 +10,13 @@ export default modifySymbol({
       type: "text",
       text: "{REF}",
       x: -0.2,
-      y: 0.2094553499999995,
+      y: 0.115,
     },
     {
       type: "text",
       text: "{VAL}",
       x: 0.2,
-      y: 0.2094553499999995,
+      y: 0.115,
     },
   ] as any,
   ports: [

--- a/symbols/capacitor_up.ts
+++ b/symbols/capacitor_up.ts
@@ -10,13 +10,13 @@ export default modifySymbol({
       type: "text",
       text: "{REF}",
       x: 0.2,
-      y: -0.2094553499999995,
+      y: -0.095,
     },
     {
       type: "text",
       text: "{VAL}",
       x: -0.2,
-      y: -0.2094553499999995,
+      y: -0.095,
     },
   ] as any,
   ports: [

--- a/tests/__snapshots__/capacitor_down.snap.svg
+++ b/tests/__snapshots__/capacitor_down.snap.svg
@@ -2,8 +2,8 @@
     <path d="M-6.938893903907228e-18,-0.11 L-3.469446951953614e-17,-0.56" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.26,0.04999999999999999 L-0.27,0.05000000000000002" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.26,-0.11000000000000001 L-0.27,-0.10999999999999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.18945534999999952" y="-0.22" dx="0" dy="0" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.1769553499999995" y="-0.2325" width="0.025" height="0.025" fill="blue" />
-    <text x="0.18945534999999952" y="0.18000000000000002" dx="0" dy="0.1" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.1769553499999995" y="0.1675" width="0.025" height="0.025" fill="blue" />
+    <text x="0.09499999999999999" y="-0.22" dx="0" dy="0" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.08249999999999999" y="-0.2325" width="0.025" height="0.025" fill="blue" />
+    <text x="0.09500000000000001" y="0.18000000000000002" dx="0" dy="0.1" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.08250000000000002" y="0.1675" width="0.025" height="0.025" fill="blue" />
 
     <rect x="-0.025000000000000036" y="-0.5950000000000001" width="0.05" height="0.05" fill="red" />
     <text x="-0.040000000000000036" y="-0.48000000000000004" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>

--- a/tests/__snapshots__/capacitor_up.snap.svg
+++ b/tests/__snapshots__/capacitor_up.snap.svg
@@ -2,8 +2,8 @@
     <path d="M-6.938893903907228e-18,0.06999999999999999 L-3.469446951953614e-17,0.52" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.26,-0.09000000000000002 L0.27,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.26,0.06999999999999998 L0.27,0.07" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.2294553499999995" y="-0.22" dx="0" dy="0" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.2169553499999995" y="-0.2325" width="0.025" height="0.025" fill="blue" />
-    <text x="0.2294553499999995" y="0.18000000000000002" dx="0" dy="0.1" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.2169553499999995" y="0.1675" width="0.025" height="0.025" fill="blue" />
+    <text x="0.11500000000000002" y="-0.22" dx="0" dy="0" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.10250000000000002" y="-0.2325" width="0.025" height="0.025" fill="blue" />
+    <text x="0.11499999999999999" y="0.18000000000000002" dx="0" dy="0.1" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.1025" y="0.1675" width="0.025" height="0.025" fill="blue" />
 
     <rect x="-0.025000000000000036" y="0.505" width="0.05" height="0.05" fill="red" />
     <text x="-0.040000000000000036" y="0.6200000000000001" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>


### PR DESCRIPTION
## Summary
- halve horizontal offset of capacitor_up labels
- halve horizontal offset of capacitor_down labels

## Testing
- `bun run build`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/snapshot-svg.test.ts`
- `bun test tests/snapshot-svg.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68bf95471ac0832eb3efe90927598cd0