### PR TITLE
fix: move REF/VAL text outside transistor symbol body

### DIFF
--- a/symbols/npn_bipolar_transistor_down.ts
+++ b/symbols/npn_bipolar_transistor_down.ts
@@ -9,13 +9,13 @@ export default modifySymbol({
     {
       type: "text",
       text: "{REF}",
-      x: -0.3,
+      x: -0.6,
       y: 0.5094553499999995,
     },
     {
       type: "text",
       text: "{VAL}",
-      x: -0.3,
+      x: -0.6,
       y: -0.5094553499999995,
     },
   ] as any,

--- a/symbols/npn_bipolar_transistor_up.ts
+++ b/symbols/npn_bipolar_transistor_up.ts
@@ -9,13 +9,13 @@ export default modifySymbol({
     {
       type: "text",
       text: "{REF}",
-      x: -0.3,
+      x: -0.6,
       y: -0.4094553499999995,
     },
     {
       type: "text",
       text: "{VAL}",
-      x: -0.3,
+      x: -0.6,
       y: 0.4094553499999995,
     },
   ] as any,

--- a/symbols/npn_bipolar_transistor_vert.ts
+++ b/symbols/npn_bipolar_transistor_vert.ts
@@ -8,13 +8,13 @@ export default modifySymbol({
     {
       type: "text",
       text: "{REF}",
-      x: -0.3,
+      x: -0.6,
       y: -0.4094553499999995,
     },
     {
       type: "text",
       text: "{VAL}",
-      x: -0.3,
+      x: -0.6,
       y: 0.4094553499999995,
     },
   ] as any,

--- a/symbols/pnp_bipolar_transistor_down.ts
+++ b/symbols/pnp_bipolar_transistor_down.ts
@@ -9,13 +9,13 @@ export default modifySymbol({
     {
       type: "text",
       text: "{REF}",
-      x: -0.1,
+      x: -0.6,
       y: 0.3094553499999995,
     },
     {
       type: "text",
       text: "{VAL}",
-      x: -0.1,
+      x: -0.6,
       y: -0.3094553499999995,
     },
   ] as any,

--- a/symbols/pnp_bipolar_transistor_left.ts
+++ b/symbols/pnp_bipolar_transistor_left.ts
@@ -9,13 +9,13 @@ export default modifySymbol({
     {
       type: "text",
       text: "{REF}",
-      x: -0.1,
+      x: -0.6,
       y: -0.3094553499999995,
     },
     {
       type: "text",
       text: "{VAL}",
-      x: -0.1,
+      x: -0.6,
       y: 0.3094553499999995,
     },
   ] as any,

--- a/symbols/pnp_bipolar_transistor_right.ts
+++ b/symbols/pnp_bipolar_transistor_right.ts
@@ -9,13 +9,13 @@ export default modifySymbol({
     {
       type: "text",
       text: "{REF}",
-      x: -0.1,
+      x: -0.6,
       y: -0.3094553499999995,
     },
     {
       type: "text",
       text: "{VAL}",
-      x: -0.1,
+      x: -0.6,
       y: 0.3094553499999995,
     },
   ] as any,

--- a/symbols/pnp_bipolar_transistor_up.ts
+++ b/symbols/pnp_bipolar_transistor_up.ts
@@ -9,13 +9,13 @@ export default modifySymbol({
     {
       type: "text",
       text: "{REF}",
-      x: -0.1,
+      x: -0.6,
       y: -0.3094553499999995,
     },
     {
       type: "text",
       text: "{VAL}",
-      x: -0.1,
+      x: -0.6,
       y: 0.3094553499999995,
     },
   ] as any,

--- a/symbols/pnp_bipolar_transistor_vert.ts
+++ b/symbols/pnp_bipolar_transistor_vert.ts
@@ -9,13 +9,13 @@ export default modifySymbol({
     {
       type: "text",
       text: "{REF}",
-      x: -0.1,
+      x: -0.6,
       y: -0.3094553499999995,
     },
     {
       type: "text",
       text: "{VAL}",
-      x: -0.1,
+      x: -0.6,
       y: 0.3094553499999995,
     },
   ] as any,

--- a/tests/__snapshots__/npn_bipolar_transistor_down.snap.svg
+++ b/tests/__snapshots__/npn_bipolar_transistor_down.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.498 -0.66 0.996 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.4,0 L0.06,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.618 -0.66 1.236 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.4,0 L0.06,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.07,-0.27 L0.07,0.28" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.28,-0.24 L0.08,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.29,0.24 L0.09,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -6,8 +6,8 @@
     <path d="M0.29,0.55 L0.29,0.25" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.19,0.1 L0.12,0.2 L0.22,0.2 L0.19,0.1" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <circle cx="0.14" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
-    <text x="-0.3" y="-0.5094553499999995" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3125" y="-0.5219553499999995" width="0.025" height="0.025" fill="blue" />
-    <text x="-0.3" y="0.5094553499999995" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3125" y="0.4969553499999995" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.6" y="-0.5094553499999995" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.6124999999999999" y="-0.5219553499999995" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.6" y="0.5094553499999995" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.6124999999999999" y="0.4969553499999995" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="0.26499999999999996" y1="-0.5750000000000001" x2="0.315" y2="-0.525" stroke="red" stroke-width="0.004" />
@@ -33,11 +33,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text>
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text></svg>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text></svg>

--- a/tests/__snapshots__/npn_bipolar_transistor_up.snap.svg
+++ b/tests/__snapshots__/npn_bipolar_transistor_up.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.498 -0.66 0.996 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.4,-4.898587196589413e-17 L-0.06,-0.009999999999999993" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.618 -0.66 1.236 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.4,-4.898587196589413e-17 L-0.06,-0.009999999999999993" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.06999999999999998,0.27 L-0.07000000000000003,-0.28" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.27999999999999997,0.24000000000000002 L-0.07999999999999999,0.11000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.29000000000000004,-0.23999999999999996 L-0.09000000000000001,-0.10999999999999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -6,8 +6,8 @@
     <path d="M-0.29000000000000004,-0.55 L-0.29000000000000004,-0.24999999999999997" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.19,-0.09999999999999998 L-0.12000000000000002,-0.19999999999999998 L-0.22000000000000003,-0.19999999999999998 L-0.19,-0.09999999999999998" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <circle cx="-0.14" cy="1.7145055188062947e-17" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
-    <text x="0.29999999999999993" y="-0.40945534999999955" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.2874999999999999" y="-0.42195534999999956" width="0.025" height="0.025" fill="blue" />
-    <text x="0.30000000000000004" y="0.40945534999999944" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.28750000000000003" y="0.39695534999999943" width="0.025" height="0.025" fill="blue" />
+    <text x="0.6" y="-0.40945534999999955" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.5875" y="-0.42195534999999956" width="0.025" height="0.025" fill="blue" />
+    <text x="0.6" y="0.40945534999999944" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.5875" y="0.39695534999999943" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.31499999999999995" y1="0.525" x2="-0.2649999999999999" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
@@ -33,11 +33,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text>
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text></svg>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text></svg>

--- a/tests/__snapshots__/npn_bipolar_transistor_vert.snap.svg
+++ b/tests/__snapshots__/npn_bipolar_transistor_vert.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.498 -0.66 0.996 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.4,-4.898587196589413e-17 L-0.06,-0.009999999999999993" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.618 -0.66 1.236 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.4,-4.898587196589413e-17 L-0.06,-0.009999999999999993" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.06999999999999998,0.27 L-0.07000000000000003,-0.28" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.27999999999999997,0.24000000000000002 L-0.07999999999999999,0.11000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.29000000000000004,-0.23999999999999996 L-0.09000000000000001,-0.10999999999999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -6,8 +6,8 @@
     <path d="M-0.29000000000000004,-0.55 L-0.29000000000000004,-0.24999999999999997" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.19,-0.09999999999999998 L-0.12000000000000002,-0.19999999999999998 L-0.22000000000000003,-0.19999999999999998 L-0.19,-0.09999999999999998" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <circle cx="-0.14" cy="1.7145055188062947e-17" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
-    <text x="0.29999999999999993" y="-0.40945534999999955" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.2874999999999999" y="-0.42195534999999956" width="0.025" height="0.025" fill="blue" />
-    <text x="0.30000000000000004" y="0.40945534999999944" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.28750000000000003" y="0.39695534999999943" width="0.025" height="0.025" fill="blue" />
+    <text x="0.6" y="-0.40945534999999955" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.5875" y="-0.42195534999999956" width="0.025" height="0.025" fill="blue" />
+    <text x="0.6" y="0.40945534999999944" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.5875" y="0.39695534999999943" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.31499999999999995" y1="0.525" x2="-0.2649999999999999" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
@@ -33,11 +33,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text>
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text></svg>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [base]</text></svg>

--- a/tests/__snapshots__/pnp_bipolar_transistor_down.snap.svg
+++ b/tests/__snapshots__/pnp_bipolar_transistor_down.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.498 -0.66 0.996 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.4,0 L0.06,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.618 -0.66 1.236 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.4,0 L0.06,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.07,-0.27 L0.07,0.28" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.28,-0.24 L0.08,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.29,0.24 L0.09,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -6,8 +6,8 @@
     <path d="M0.29,0.55 L0.29,0.25" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.15,0.23 L0.22,0.12 L0.12,0.12 L0.15,0.23" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <circle cx="0.14" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
-    <text x="-0.1" y="-0.3094553499999995" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.1125" y="-0.32195534999999953" width="0.025" height="0.025" fill="blue" />
-    <text x="-0.1" y="0.3094553499999995" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.1125" y="0.2969553499999995" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.6" y="-0.3094553499999995" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.6124999999999999" y="-0.32195534999999953" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.6" y="0.3094553499999995" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.6124999999999999" y="0.2969553499999995" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="0.26499999999999996" y1="-0.5750000000000001" x2="0.315" y2="-0.525" stroke="red" stroke-width="0.004" />
@@ -33,11 +33,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>

--- a/tests/__snapshots__/pnp_bipolar_transistor_left.snap.svg
+++ b/tests/__snapshots__/pnp_bipolar_transistor_left.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.66 -0.498 1.32 0.996" xmlns="http://www.w3.org/2000/svg"><path d="M-2.4492935982947065e-17,-0.4 L-0.009999999999999997,0.06" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.66 -0.618 1.32 1.236" xmlns="http://www.w3.org/2000/svg"><path d="M-2.4492935982947065e-17,-0.4 L-0.009999999999999997,0.06" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.27,0.06999999999999999 L-0.28,0.07000000000000002" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.24000000000000002,0.28 L0.11,0.08" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.23999999999999996,0.29 L-0.11,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -6,8 +6,8 @@
     <path d="M-0.55,0.29000000000000004 L-0.24999999999999997,0.29" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.23,0.15000000000000002 L-0.11999999999999998,0.22 L-0.11999999999999998,0.12000000000000001 L-0.23,0.15000000000000002" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <circle cx="8.572527594031473e-18" cy="0.14" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
-    <text x="-0.3094553499999995" y="-0.09999999999999999" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.32195534999999953" y="-0.11249999999999999" width="0.025" height="0.025" fill="blue" />
-    <text x="0.3094553499999995" y="-0.10000000000000002" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.2969553499999995" y="-0.11250000000000002" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.3094553499999996" y="-0.6" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3219553499999996" y="-0.6124999999999999" width="0.025" height="0.025" fill="blue" />
+    <text x="0.30945534999999946" y="-0.6" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.29695534999999945" y="-0.6124999999999999" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="0.525" y1="0.2649999999999999" x2="0.5750000000000001" y2="0.31499999999999995" stroke="red" stroke-width="0.004" />
@@ -33,11 +33,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.55" y="-0.41500000000000004" style="font: 0.05px monospace; fill: #833;">1.10 x 0.83</text>
-<text x="-0.55" y="-0.465" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.55" y="-0.515" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.55" y="-0.5650000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
-<text x="-0.55" y="-0.41500000000000004" style="font: 0.05px monospace; fill: #833;">1.10 x 0.83</text>
-<text x="-0.55" y="-0.465" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.55" y="-0.515" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.55" y="-0.5650000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>
+<text x="-0.55" y="-0.515" style="font: 0.05px monospace; fill: #833;">1.10 x 1.03</text>
+<text x="-0.55" y="-0.5650000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.55" y="-0.615" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.55" y="-0.665" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
+<text x="-0.55" y="-0.515" style="font: 0.05px monospace; fill: #833;">1.10 x 1.03</text>
+<text x="-0.55" y="-0.5650000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.55" y="-0.615" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.55" y="-0.665" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>

--- a/tests/__snapshots__/pnp_bipolar_transistor_right.snap.svg
+++ b/tests/__snapshots__/pnp_bipolar_transistor_right.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.66 -0.498 1.32 0.996" xmlns="http://www.w3.org/2000/svg"><path d="M-2.4492935982947065e-17,0.4 L0.010000000000000004,-0.06" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.66 -0.618 1.32 1.236" xmlns="http://www.w3.org/2000/svg"><path d="M-2.4492935982947065e-17,0.4 L0.010000000000000004,-0.06" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.27,-0.07000000000000002 L0.28,-0.06999999999999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.23999999999999996,-0.28 L-0.11,-0.08" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.24000000000000002,-0.29 L0.11,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -6,8 +6,8 @@
     <path d="M0.55,-0.2899999999999999 L0.25,-0.29" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.23,-0.14999999999999997 L0.12000000000000001,-0.22 L0.12000000000000001,-0.11999999999999998 L0.23,-0.14999999999999997" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <circle cx="8.572527594031473e-18" cy="-0.14" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
-    <text x="0.3094553499999995" y="0.10000000000000002" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.2969553499999995" y="0.08750000000000002" width="0.025" height="0.025" fill="blue" />
-    <text x="-0.3094553499999995" y="0.09999999999999999" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.32195534999999953" y="0.0875" width="0.025" height="0.025" fill="blue" />
+    <text x="0.30945534999999946" y="0.6" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.29695534999999945" y="0.5875" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.3094553499999996" y="0.6" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3219553499999996" y="0.5875" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.5750000000000001" y1="-0.31500000000000006" x2="-0.525" y2="-0.265" stroke="red" stroke-width="0.004" />
@@ -33,11 +33,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.55" y="-0.41500000000000004" style="font: 0.05px monospace; fill: #833;">1.10 x 0.83</text>
-<text x="-0.55" y="-0.465" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.55" y="-0.515" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.55" y="-0.5650000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
-<text x="-0.55" y="-0.41500000000000004" style="font: 0.05px monospace; fill: #833;">1.10 x 0.83</text>
-<text x="-0.55" y="-0.465" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.55" y="-0.515" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.55" y="-0.5650000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>
+<text x="-0.55" y="-0.515" style="font: 0.05px monospace; fill: #833;">1.10 x 1.03</text>
+<text x="-0.55" y="-0.5650000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.55" y="-0.615" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.55" y="-0.665" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
+<text x="-0.55" y="-0.515" style="font: 0.05px monospace; fill: #833;">1.10 x 1.03</text>
+<text x="-0.55" y="-0.5650000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.55" y="-0.615" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.55" y="-0.665" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>

--- a/tests/__snapshots__/pnp_bipolar_transistor_up.snap.svg
+++ b/tests/__snapshots__/pnp_bipolar_transistor_up.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.498 -0.66 0.996 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.4,-4.898587196589413e-17 L-0.06,-0.009999999999999993" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.618 -0.66 1.236 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.4,-4.898587196589413e-17 L-0.06,-0.009999999999999993" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.06999999999999998,0.27 L-0.07000000000000003,-0.28" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.27999999999999997,0.24000000000000002 L-0.07999999999999999,0.11000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.29000000000000004,-0.23999999999999996 L-0.09000000000000001,-0.10999999999999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -6,8 +6,8 @@
     <path d="M-0.29000000000000004,-0.55 L-0.29000000000000004,-0.24999999999999997" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.15000000000000002,-0.22999999999999998 L-0.22000000000000003,-0.11999999999999997 L-0.12000000000000001,-0.11999999999999998 L-0.15000000000000002,-0.22999999999999998" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <circle cx="-0.14" cy="1.7145055188062947e-17" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
-    <text x="0.09999999999999996" y="-0.3094553499999995" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.08749999999999997" y="-0.32195534999999953" width="0.025" height="0.025" fill="blue" />
-    <text x="0.10000000000000005" y="0.3094553499999995" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.08750000000000005" y="0.2969553499999995" width="0.025" height="0.025" fill="blue" />
+    <text x="0.6" y="-0.3094553499999996" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.5875" y="-0.3219553499999996" width="0.025" height="0.025" fill="blue" />
+    <text x="0.6" y="0.30945534999999946" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.5875" y="0.29695534999999945" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.31499999999999995" y1="0.525" x2="-0.2649999999999999" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
@@ -33,11 +33,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>

--- a/tests/__snapshots__/pnp_bipolar_transistor_vert.snap.svg
+++ b/tests/__snapshots__/pnp_bipolar_transistor_vert.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.498 -0.66 0.996 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.4,-4.898587196589413e-17 L-0.06,-0.009999999999999993" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.618 -0.66 1.236 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.4,-4.898587196589413e-17 L-0.06,-0.009999999999999993" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.06999999999999998,0.27 L-0.07000000000000003,-0.28" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.27999999999999997,0.24000000000000002 L-0.07999999999999999,0.11000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.29000000000000004,-0.23999999999999996 L-0.09000000000000001,-0.10999999999999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -6,8 +6,8 @@
     <path d="M-0.29000000000000004,-0.55 L-0.29000000000000004,-0.24999999999999997" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.15000000000000002,-0.22999999999999998 L-0.22000000000000003,-0.11999999999999997 L-0.12000000000000001,-0.11999999999999998 L-0.15000000000000002,-0.22999999999999998" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <circle cx="-0.14" cy="1.7145055188062947e-17" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
-    <text x="0.09999999999999996" y="-0.3094553499999995" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.08749999999999997" y="-0.32195534999999953" width="0.025" height="0.025" fill="blue" />
-    <text x="0.10000000000000005" y="0.3094553499999995" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.08750000000000005" y="0.2969553499999995" width="0.025" height="0.025" fill="blue" />
+    <text x="0.6" y="-0.3094553499999996" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.5875" y="-0.3219553499999996" width="0.025" height="0.025" fill="blue" />
+    <text x="0.6" y="0.30945534999999946" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.5875" y="0.29695534999999945" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.31499999999999995" y1="0.525" x2="-0.2649999999999999" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
@@ -33,11 +33,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
-<text x="-0.41500000000000004" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.83 x 1.10</text>
-<text x="-0.41500000000000004" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
-<text x="-0.41500000000000004" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
-<text x="-0.41500000000000004" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text>
+<text x="-0.515" y="-0.55" style="font: 0.05px monospace; fill: #833;">1.03 x 1.10</text>
+<text x="-0.515" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [collector]</text>
+<text x="-0.515" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [emitter]</text>
+<text x="-0.515" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [base]</text></svg>


### PR DESCRIPTION
## Summary

Fixes #375 — REF text overlaps with the transistor symbol body.

## Problem

The `{REF}` and `{VAL}` text labels for bipolar transistor symbols were positioned at `x=-0.1` to `x=-0.3`, which falls inside the symbol body (bounds: `-0.43` to `0.43`). After rotation (e.g., `rotateRightFacingSymbol("left")`), the text overlaps with the transistor graphic.

## Fix

Moved text x-positions from `-0.1`/`-0.3` → `-0.6` so they render clearly outside the symbol in all orientations.

## Affected symbols (8 files)

- `npn_bipolar_transistor_vert.ts`
- `npn_bipolar_transistor_up.ts`
- `npn_bipolar_transistor_down.ts`
- `pnp_bipolar_transistor_vert.ts`
- `pnp_bipolar_transistor_up.ts`
- `pnp_bipolar_transistor_down.ts`
- `pnp_bipolar_transistor_left.ts`
- `pnp_bipolar_transistor_right.ts`

## Testing

- ✅ `bun test` — 8 pass, 0 fail
- ✅ Snapshot SVGs updated — REF text now at `x=0.6` (outside symbol bounds)
- ✅ `bun run build` passes
- ✅ Snapshot validation passes