### PR TITLE
fix: close filled gunn diode paths

### DIFF
--- a/assets/generated/gunn_diode.json
+++ b/assets/generated/gunn_diode.json
@@ -51,7 +51,8 @@
         }
       ],
       "color": "primary",
-      "fill": true
+      "fill": true,
+      "closed": true
     },
     "path11-0-9-5": {
       "type": "path",
@@ -74,7 +75,8 @@
         }
       ],
       "color": "primary",
-      "fill": true
+      "fill": true,
+      "closed": true
     }
   },
   "texts": {

--- a/assets/symbols/gunn_diode.svg
+++ b/assets/symbols/gunn_diode.svg
@@ -110,13 +110,13 @@
          transform="rotate(-90)" />
       <path
          style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.230463px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 56.655216,-93.70596 3.040649,0.01747 -1.43598,-2.980574 -1.612808,2.93001"
+         d="m 56.655216,-93.70596 3.040649,0.01747 -1.43598,-2.980574 -1.612808,2.93001 z"
          id="path11-0-9"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />
       <path
          style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.230463px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 56.646838,-100.09766 3.040649,-0.0175 -1.43598,2.980569 -1.612808,-2.930009"
+         d="m 56.646838,-100.09766 3.040649,-0.0175 -1.43598,2.980569 -1.612808,-2.930009 z"
          id="path11-0-9-5"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />

--- a/scripts/lib/svg-generation-fns/svg-generation-fns.ts
+++ b/scripts/lib/svg-generation-fns/svg-generation-fns.ts
@@ -12,6 +12,8 @@ import kleur from "kleur"
 
 const SOURCE_IGNORE_LIST = ["testshape"]
 
+const isClosedPath = (pathData: string) => /[zZ]\s*$/.test(pathData.trim())
+
 /**
  * Inkscape SVGs are generated with "Y-up is negative", but we want "Y-up is positive"
  */
@@ -98,6 +100,7 @@ export async function processSvg(
                 fill:
                   path.attributes.fill === "true" &&
                   !path.attributes.style?.includes("fill:none"),
+                ...(isClosedPath(path.attributes.d!) ? { closed: true } : {}),
               },
             ]),
           )


### PR DESCRIPTION
Fixes #418.

The Gunn diode symbol had filled regions defined as open paths. This closes the two filled source SVG paths and preserves closed paths when regenerating symbol JSON, so renderers can treat those regions as filled shapes consistently.

Tests:
- `bun test`
- `npx tsc --noEmit`

Build note: `bun run build` was not completed locally because `esbuild` failed to spawn on this Windows environment.