### PR TITLE
Fix switch and MOSFET symbol terminal alignment for schematic routing

### DIFF
--- a/drawing/getSizeForCenteredTerminalBox.ts
+++ b/drawing/getSizeForCenteredTerminalBox.ts
@@ -1,0 +1,17 @@
+import type { Point } from "drawing/types"
+
+export function getSizeForCenteredTerminalBox(
+  center: Point,
+  terminals: Point[],
+) {
+  return {
+    width:
+      Math.max(
+        ...terminals.map((terminal) => Math.abs(terminal.x - center.x)),
+      ) * 2,
+    height:
+      Math.max(
+        ...terminals.map((terminal) => Math.abs(terminal.y - center.y)),
+      ) * 2,
+  }
+}

--- a/symbols/mosfet_depletion_normally_on_horz.ts
+++ b/symbols/mosfet_depletion_normally_on_horz.ts
@@ -1,7 +1,9 @@
 import svgJson from "assets/generated/mosfet_depletion_normally_on.json"
 import { defineSymbol } from "drawing/defineSymbol"
+import { getSizeForCenteredTerminalBox } from "drawing/getSizeForCenteredTerminalBox"
 
 const { paths, texts, bounds, refblocks } = svgJson
+const center = { x: bounds.centerX + 0.2, y: bounds.centerY }
 
 export default defineSymbol({
   primitives: [
@@ -14,6 +16,10 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3"] }, // TODO add more "standard" labels
   ],
-  size: { width: 1.48, height: 1.08 },
-  center: { x: bounds.centerX + 0.2, y: bounds.centerY },
+  size: getSizeForCenteredTerminalBox(center, [
+    refblocks.top1,
+    refblocks.bottom1,
+    refblocks.left1,
+  ]),
+  center,
 })

--- a/symbols/mosfet_depletion_normally_on_horz.ts
+++ b/symbols/mosfet_depletion_normally_on_horz.ts
@@ -14,6 +14,6 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3"] }, // TODO add more "standard" labels
   ],
-  size: { width: bounds.width + 0.4, height: bounds.height },
+  size: { width: 1.48, height: 1.08 },
   center: { x: bounds.centerX + 0.2, y: bounds.centerY },
 })

--- a/symbols/n_channel_d_mosfet_transistor_horz.ts
+++ b/symbols/n_channel_d_mosfet_transistor_horz.ts
@@ -15,6 +15,6 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2", "source"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3", "gate"] }, // TODO add more "standard" labels
   ],
-  size: { width: bounds.width, height: bounds.height },
+  size: { width: 0.84, height: 1.1 },
   center: { x: bounds.centerX, y: bounds.centerY },
 })

--- a/symbols/n_channel_d_mosfet_transistor_horz.ts
+++ b/symbols/n_channel_d_mosfet_transistor_horz.ts
@@ -1,7 +1,9 @@
 import { defineSymbol } from "drawing/defineSymbol"
+import { getSizeForCenteredTerminalBox } from "drawing/getSizeForCenteredTerminalBox"
 import svgJson from "assets/generated/n_channel_d_mosfet_transistor.json"
 
 const { paths, texts, bounds, refblocks, circles } = svgJson
+const center = { x: bounds.centerX, y: bounds.centerY }
 
 export default defineSymbol({
   primitives: [
@@ -15,6 +17,10 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2", "source"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3", "gate"] }, // TODO add more "standard" labels
   ],
-  size: { width: 0.84, height: 1.1 },
-  center: { x: bounds.centerX, y: bounds.centerY },
+  size: getSizeForCenteredTerminalBox(center, [
+    refblocks.top1,
+    refblocks.bottom1,
+    refblocks.left1,
+  ]),
+  center,
 })

--- a/symbols/n_channel_e_mosfet_transistor_horz.ts
+++ b/symbols/n_channel_e_mosfet_transistor_horz.ts
@@ -1,8 +1,10 @@
 import { defineSymbol } from "drawing/defineSymbol"
+import { getSizeForCenteredTerminalBox } from "drawing/getSizeForCenteredTerminalBox"
 import svgJson from "assets/generated/n_channel_e_mosfet_transistor.json"
 import { Primitive } from "drawing/types"
 
 const { paths, texts, bounds, refblocks, circles } = svgJson
+const center = { x: bounds.centerX, y: bounds.centerY }
 
 export default defineSymbol({
   primitives: [
@@ -16,6 +18,10 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2", "source"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3", "gate"] }, // TODO add more "standard" labels
   ],
-  size: { width: 0.84, height: 1.1 },
-  center: { x: bounds.centerX, y: bounds.centerY },
+  size: getSizeForCenteredTerminalBox(center, [
+    refblocks.top1,
+    refblocks.bottom1,
+    refblocks.left1,
+  ]),
+  center,
 })

--- a/symbols/n_channel_e_mosfet_transistor_horz.ts
+++ b/symbols/n_channel_e_mosfet_transistor_horz.ts
@@ -16,6 +16,6 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2", "source"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3", "gate"] }, // TODO add more "standard" labels
   ],
-  size: { width: bounds.width, height: bounds.height },
+  size: { width: 0.84, height: 1.1 },
   center: { x: bounds.centerX, y: bounds.centerY },
 })

--- a/symbols/p_channel_d_mosfet_transistor_horz.ts
+++ b/symbols/p_channel_d_mosfet_transistor_horz.ts
@@ -15,6 +15,6 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2", "source"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3", "gate"] }, // TODO add more "standard" labels
   ],
-  size: { width: bounds.width, height: bounds.height },
+  size: { width: 0.84, height: 1.1 },
   center: { x: bounds.centerX, y: bounds.centerY },
 })

--- a/symbols/p_channel_d_mosfet_transistor_horz.ts
+++ b/symbols/p_channel_d_mosfet_transistor_horz.ts
@@ -1,7 +1,9 @@
 import { defineSymbol } from "drawing/defineSymbol"
+import { getSizeForCenteredTerminalBox } from "drawing/getSizeForCenteredTerminalBox"
 import svgJson from "assets/generated/p_channel_d_mosfet_transistor.json"
 
 const { paths, texts, bounds, refblocks, circles } = svgJson
+const center = { x: bounds.centerX, y: bounds.centerY }
 
 export default defineSymbol({
   primitives: [
@@ -15,6 +17,10 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2", "source"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3", "gate"] }, // TODO add more "standard" labels
   ],
-  size: { width: 0.84, height: 1.1 },
-  center: { x: bounds.centerX, y: bounds.centerY },
+  size: getSizeForCenteredTerminalBox(center, [
+    refblocks.top1,
+    refblocks.bottom1,
+    refblocks.left1,
+  ]),
+  center,
 })

--- a/symbols/p_channel_e_mosfet_transistor_horz.ts
+++ b/symbols/p_channel_e_mosfet_transistor_horz.ts
@@ -15,6 +15,6 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2", "source"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3", "gate"] }, // TODO add more "standard" labels
   ],
-  size: { width: bounds.width, height: bounds.height },
+  size: { width: 0.84, height: 1.1 },
   center: { x: bounds.centerX, y: bounds.centerY },
 })

--- a/symbols/p_channel_e_mosfet_transistor_horz.ts
+++ b/symbols/p_channel_e_mosfet_transistor_horz.ts
@@ -1,7 +1,9 @@
 import { defineSymbol } from "drawing/defineSymbol"
+import { getSizeForCenteredTerminalBox } from "drawing/getSizeForCenteredTerminalBox"
 import svgJson from "assets/generated/p_channel_e_mosfet_transistor.json"
 
 const { paths, texts, bounds, refblocks, circles } = svgJson
+const center = { x: bounds.centerX, y: bounds.centerY }
 
 export default defineSymbol({
   primitives: [
@@ -15,6 +17,10 @@ export default defineSymbol({
     { ...refblocks.bottom1, labels: ["2", "source"] }, // TODO add more "standard" labels
     { ...refblocks.left1, labels: ["3", "gate"] }, // TODO add more "standard" labels
   ],
-  size: { width: 0.84, height: 1.1 },
-  center: { x: bounds.centerX, y: bounds.centerY },
+  size: getSizeForCenteredTerminalBox(center, [
+    refblocks.top1,
+    refblocks.bottom1,
+    refblocks.left1,
+  ]),
+  center,
 })

--- a/symbols/push_button_normally_closed_momentary_horz.ts
+++ b/symbols/push_button_normally_closed_momentary_horz.ts
@@ -15,6 +15,5 @@ export default defineSymbol({
     { ...refblocks.left1, labels: ["1"] }, // TODO add more "standard" labels
     { ...refblocks.right1, labels: ["2"] }, // TODO add more "standard" labels
   ],
-  size: { width: bounds.width, height: bounds.height },
   center: { x: bounds.centerX, y: bounds.centerY },
 })

--- a/symbols/push_button_normally_open_momentary_horz.ts
+++ b/symbols/push_button_normally_open_momentary_horz.ts
@@ -15,6 +15,5 @@ export default defineSymbol({
     { ...refblocks.left1, labels: ["1"] }, // TODO add more "standard" labels
     { ...refblocks.right1, labels: ["2"] }, // TODO add more "standard" labels
   ],
-  size: { width: bounds.width, height: bounds.height },
   center: { x: bounds.centerX, y: bounds.centerY },
 })

--- a/symbols/push_button_normally_open_momentary_right.ts
+++ b/symbols/push_button_normally_open_momentary_right.ts
@@ -15,6 +15,5 @@ export default defineSymbol({
     { ...refblocks.left1, labels: ["1"] }, // TODO add more "standard" labels
     { ...refblocks.right1, labels: ["2"] }, // TODO add more "standard" labels
   ],
-  size: { width: bounds.width, height: bounds.height },
   center: { x: bounds.centerX, y: bounds.centerY },
 })

--- a/tests/__snapshots__/mosfet_depletion_normally_on_horz.snap.svg
+++ b/tests/__snapshots__/mosfet_depletion_normally_on_horz.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.724 -0.6839999999999999 1.8479999999999999 1.3679999999999999" xmlns="http://www.w3.org/2000/svg"><path d="M0.38,-0.13 L0.52,0.13" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.688 -0.648 1.776 1.296" xmlns="http://www.w3.org/2000/svg"><path d="M0.38,-0.13 L0.52,0.13" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.25,0.13 L0.38,-0.13" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.52,0.13 L0.25,0.13" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.25,-0.13 L0.52,-0.13" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -40,5 +40,5 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0.2 -0.025 L 0.225 0 L 0.2 0.025 L 0.17500000000000002 0 Z" fill="green" />
-<text x="-0.5700000000000001" y="-0.57" style="font: 0.05px monospace; fill: #833;">1.54 x 1.14</text>
-<text x="-0.5700000000000001" y="-0.57" style="font: 0.05px monospace; fill: #833;">1.54 x 1.14</text></svg>
+<text x="-0.54" y="-0.54" style="font: 0.05px monospace; fill: #833;">1.48 x 1.08</text>
+<text x="-0.54" y="-0.54" style="font: 0.05px monospace; fill: #833;">1.48 x 1.08</text></svg>

--- a/tests/__snapshots__/n_channel_d_mosfet_transistor_horz.snap.svg
+++ b/tests/__snapshots__/n_channel_d_mosfet_transistor_horz.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.534 -0.696 1.068 1.392" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.09,-0.19 L0.09,0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.3,-0.55 L0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.31,0.55 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -35,11 +35,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.445" y="-0.58" style="font: 0.05px monospace; fill: #833;">0.89 x 1.16</text>
-<text x="-0.445" y="-0.63" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
-<text x="-0.445" y="-0.6799999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
-<text x="-0.445" y="-0.73" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
-<text x="-0.445" y="-0.58" style="font: 0.05px monospace; fill: #833;">0.89 x 1.16</text>
-<text x="-0.445" y="-0.63" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
-<text x="-0.445" y="-0.6799999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
-<text x="-0.445" y="-0.73" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_e_mosfet_transistor_horz.snap.svg
+++ b/tests/__snapshots__/n_channel_e_mosfet_transistor_horz.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.534 -0.696 1.068 1.392" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.3,-0.55 L0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.31,0.55 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.09,-0.11 L0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -37,11 +37,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.445" y="-0.58" style="font: 0.05px monospace; fill: #833;">0.89 x 1.16</text>
-<text x="-0.445" y="-0.63" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
-<text x="-0.445" y="-0.6799999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
-<text x="-0.445" y="-0.73" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
-<text x="-0.445" y="-0.58" style="font: 0.05px monospace; fill: #833;">0.89 x 1.16</text>
-<text x="-0.445" y="-0.63" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
-<text x="-0.445" y="-0.6799999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
-<text x="-0.445" y="-0.73" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_d_mosfet_transistor_horz.snap.svg
+++ b/tests/__snapshots__/p_channel_d_mosfet_transistor_horz.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.534 -0.696 1.068 1.392" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.09,-0.19 L0.09,0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.3,-0.55 L0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.31,0.55 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -35,11 +35,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.445" y="-0.58" style="font: 0.05px monospace; fill: #833;">0.89 x 1.16</text>
-<text x="-0.445" y="-0.63" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
-<text x="-0.445" y="-0.6799999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
-<text x="-0.445" y="-0.73" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
-<text x="-0.445" y="-0.58" style="font: 0.05px monospace; fill: #833;">0.89 x 1.16</text>
-<text x="-0.445" y="-0.63" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
-<text x="-0.445" y="-0.6799999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
-<text x="-0.445" y="-0.73" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_e_mosfet_transistor_horz.snap.svg
+++ b/tests/__snapshots__/p_channel_e_mosfet_transistor_horz.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.534 -0.696 1.068 1.392" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.3,-0.55 L0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.31,0.55 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.09,-0.11 L0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -37,11 +37,11 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.445" y="-0.58" style="font: 0.05px monospace; fill: #833;">0.89 x 1.16</text>
-<text x="-0.445" y="-0.63" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
-<text x="-0.445" y="-0.6799999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
-<text x="-0.445" y="-0.73" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
-<text x="-0.445" y="-0.58" style="font: 0.05px monospace; fill: #833;">0.89 x 1.16</text>
-<text x="-0.445" y="-0.63" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
-<text x="-0.445" y="-0.6799999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
-<text x="-0.445" y="-0.73" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/push_button_normally_closed_momentary_horz.snap.svg
+++ b/tests/__snapshots__/push_button_normally_closed_momentary_horz.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.6 -0.27 1.2 0.54" xmlns="http://www.w3.org/2000/svg"><path d="M0.01,-0.03 L0.01,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.564 -0.264 1.128 0.528" xmlns="http://www.w3.org/2000/svg"><path d="M0.01,-0.03 L0.01,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.47,0.05 L-0.17,0.05" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.16,0.09 L0.18,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.2,0.05 L0.47,0.05" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -23,5 +23,5 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.5" y="-0.225" style="font: 0.05px monospace; fill: #833;">1.00 x 0.45</text>
-<text x="-0.5" y="-0.225" style="font: 0.05px monospace; fill: #833;">1.00 x 0.45</text></svg>
+<text x="-0.47" y="-0.22" style="font: 0.05px monospace; fill: #833;">0.94 x 0.44</text>
+<text x="-0.47" y="-0.22" style="font: 0.05px monospace; fill: #833;">0.94 x 0.44</text></svg>

--- a/tests/__snapshots__/push_button_normally_open_momentary_horz.snap.svg
+++ b/tests/__snapshots__/push_button_normally_open_momentary_horz.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.6 -0.27 1.2 0.54" xmlns="http://www.w3.org/2000/svg"><path d="M-0.05,-0.09 L-0.05,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.564 -0.4313464199999994 1.128 0.8626928399999988" xmlns="http://www.w3.org/2000/svg"><path d="M-0.05,-0.09 L-0.05,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.05,-0.09 L0.07,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.07,-0.09 L0.07,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.47,0.05 L-0.17,0.05" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -25,5 +25,5 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.5" y="-0.225" style="font: 0.05px monospace; fill: #833;">1.00 x 0.45</text>
-<text x="-0.5" y="-0.225" style="font: 0.05px monospace; fill: #833;">1.00 x 0.45</text></svg>
+<text x="-0.47" y="-0.3594553499999995" style="font: 0.05px monospace; fill: #833;">0.94 x 0.72</text>
+<text x="-0.47" y="-0.3594553499999995" style="font: 0.05px monospace; fill: #833;">0.94 x 0.72</text></svg>

--- a/tests/__snapshots__/push_button_normally_open_momentary_right.snap.svg
+++ b/tests/__snapshots__/push_button_normally_open_momentary_right.snap.svg
@@ -1,4 +1,4 @@
-<svg width="150" height="150" viewBox="-0.6 -0.27 1.2 0.54" xmlns="http://www.w3.org/2000/svg"><path d="M-0.05,-0.09 L-0.05,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.564 -0.4313464199999994 1.128 0.8626928399999988" xmlns="http://www.w3.org/2000/svg"><path d="M-0.05,-0.09 L-0.05,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.05,-0.09 L0.07,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.07,-0.09 L0.07,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.47,0.05 L-0.17,0.05" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
@@ -25,5 +25,5 @@
       text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.5" y="-0.225" style="font: 0.05px monospace; fill: #833;">1.00 x 0.45</text>
-<text x="-0.5" y="-0.225" style="font: 0.05px monospace; fill: #833;">1.00 x 0.45</text></svg>
+<text x="-0.47" y="-0.3594553499999995" style="font: 0.05px monospace; fill: #833;">0.94 x 0.72</text>
+<text x="-0.47" y="-0.3594553499999995" style="font: 0.05px monospace; fill: #833;">0.94 x 0.72</text></svg>

--- a/tests/getSizeForCenteredTerminalBox.test.ts
+++ b/tests/getSizeForCenteredTerminalBox.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { getSizeForCenteredTerminalBox } from "drawing/getSizeForCenteredTerminalBox"
+
+test("gets a terminal-aligned size from centered terminal positions", () => {
+  const center = { x: 0, y: 0 }
+  const drainTerminal = { x: 0.3, y: 0.55 }
+  const sourceTerminal = { x: 0.31, y: -0.55 }
+  const gateTerminal = { x: -0.42, y: -0.1 }
+
+  expect(
+    getSizeForCenteredTerminalBox(center, [
+      drainTerminal,
+      sourceTerminal,
+      gateTerminal,
+    ]),
+  ).toEqual({
+    width: Math.abs(gateTerminal.x - center.x) * 2,
+    height: Math.abs(drainTerminal.y - center.y) * 2,
+  })
+})


### PR DESCRIPTION
Fixes disconnected-looking schematic traces by correcting switch and MOSFET symbol bounds so  routing edges line up with the actual terminal  positions. Pushbutton symbols now use their  true primitive bounds instead of stale explicit sizes, and horizontal MOSFET symbols  derive their size from drain/source/gate  terminal positions instead of magic numbers,  with snapshots and a focused regression test  updated to cover the behavior.

linked locally to core 

BEFORE: 

<img width="285" height="167" alt="image" src="https://github.com/user-attachments/assets/e4d92666-c6e9-4c8c-b19b-02954b7061c2" />


AFTER: 

<img width="229" height="171" alt="image" src="https://github.com/user-attachments/assets/1e886f6c-0f10-42f2-9363-0828fc0d7336" />
