### PR TITLE
Add MOSFET orientation variants

### DIFF
--- a/drawing/createMosfetSymbolVariant.ts
+++ b/drawing/createMosfetSymbolVariant.ts
@@ -1,0 +1,35 @@
+import { flipSymbolOverXAxis, flipSymbolOverYAxis } from "./rotateSymbol"
+import type { SchSymbol } from "./types"
+
+type SymbolSide = "left" | "right" | "top" | "bottom"
+
+export const createMosfetSymbolVariant = ({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide,
+  drainSide,
+}: {
+  horizontalSymbol: SchSymbol
+  verticalSymbol: SchSymbol
+  gateSide: SymbolSide
+  drainSide: SymbolSide
+}): SchSymbol => {
+  const isHorizontalGate = gateSide === "left" || gateSide === "right"
+  const isHorizontalDrain = drainSide === "left" || drainSide === "right"
+  if (isHorizontalGate === isHorizontalDrain) {
+    throw new Error(
+      `Invalid MOSFET orientation: gate ${gateSide}, drain ${drainSide}. Gate and drain must be perpendicular.`,
+    )
+  }
+
+  let symbol = isHorizontalGate ? horizontalSymbol : verticalSymbol
+
+  if (gateSide === "right" || (isHorizontalDrain && drainSide === "left")) {
+    symbol = flipSymbolOverYAxis(symbol)
+  }
+  if (gateSide === "bottom" || (!isHorizontalDrain && drainSide === "bottom")) {
+    symbol = flipSymbolOverXAxis(symbol)
+  }
+
+  return symbol
+}

--- a/generated/symbols-index.ts
+++ b/generated/symbols-index.ts
@@ -150,8 +150,24 @@ import _mosfet_depletion_normally_on_horz from "./../symbols/mosfet_depletion_no
 import _mosfet_depletion_normally_on_vert from "./../symbols/mosfet_depletion_normally_on_vert"
 import _mushroom_head_normally_open_momentary_horz from "./../symbols/mushroom_head_normally_open_momentary_horz"
 import _mushroom_head_normally_open_momentary_vert from "./../symbols/mushroom_head_normally_open_momentary_vert"
+import _n_channel_d_mosfet_transistor_gate_bottom_drain_left from "./../symbols/n_channel_d_mosfet_transistor_gate_bottom_drain_left"
+import _n_channel_d_mosfet_transistor_gate_bottom_drain_right from "./../symbols/n_channel_d_mosfet_transistor_gate_bottom_drain_right"
+import _n_channel_d_mosfet_transistor_gate_left_drain_bottom from "./../symbols/n_channel_d_mosfet_transistor_gate_left_drain_bottom"
+import _n_channel_d_mosfet_transistor_gate_left_drain_top from "./../symbols/n_channel_d_mosfet_transistor_gate_left_drain_top"
+import _n_channel_d_mosfet_transistor_gate_right_drain_bottom from "./../symbols/n_channel_d_mosfet_transistor_gate_right_drain_bottom"
+import _n_channel_d_mosfet_transistor_gate_right_drain_top from "./../symbols/n_channel_d_mosfet_transistor_gate_right_drain_top"
+import _n_channel_d_mosfet_transistor_gate_top_drain_left from "./../symbols/n_channel_d_mosfet_transistor_gate_top_drain_left"
+import _n_channel_d_mosfet_transistor_gate_top_drain_right from "./../symbols/n_channel_d_mosfet_transistor_gate_top_drain_right"
 import _n_channel_d_mosfet_transistor_horz from "./../symbols/n_channel_d_mosfet_transistor_horz"
 import _n_channel_d_mosfet_transistor_vert from "./../symbols/n_channel_d_mosfet_transistor_vert"
+import _n_channel_e_mosfet_transistor_gate_bottom_drain_left from "./../symbols/n_channel_e_mosfet_transistor_gate_bottom_drain_left"
+import _n_channel_e_mosfet_transistor_gate_bottom_drain_right from "./../symbols/n_channel_e_mosfet_transistor_gate_bottom_drain_right"
+import _n_channel_e_mosfet_transistor_gate_left_drain_bottom from "./../symbols/n_channel_e_mosfet_transistor_gate_left_drain_bottom"
+import _n_channel_e_mosfet_transistor_gate_left_drain_top from "./../symbols/n_channel_e_mosfet_transistor_gate_left_drain_top"
+import _n_channel_e_mosfet_transistor_gate_right_drain_bottom from "./../symbols/n_channel_e_mosfet_transistor_gate_right_drain_bottom"
+import _n_channel_e_mosfet_transistor_gate_right_drain_top from "./../symbols/n_channel_e_mosfet_transistor_gate_right_drain_top"
+import _n_channel_e_mosfet_transistor_gate_top_drain_left from "./../symbols/n_channel_e_mosfet_transistor_gate_top_drain_left"
+import _n_channel_e_mosfet_transistor_gate_top_drain_right from "./../symbols/n_channel_e_mosfet_transistor_gate_top_drain_right"
 import _n_channel_e_mosfet_transistor_horz from "./../symbols/n_channel_e_mosfet_transistor_horz"
 import _n_channel_e_mosfet_transistor_vert from "./../symbols/n_channel_e_mosfet_transistor_vert"
 import _njfet_transistor_horz from "./../symbols/njfet_transistor_horz"
@@ -174,8 +190,24 @@ import _opamp_with_power_down from "./../symbols/opamp_with_power_down"
 import _opamp_with_power_left from "./../symbols/opamp_with_power_left"
 import _opamp_with_power_right from "./../symbols/opamp_with_power_right"
 import _opamp_with_power_up from "./../symbols/opamp_with_power_up"
+import _p_channel_d_mosfet_transistor_gate_bottom_drain_left from "./../symbols/p_channel_d_mosfet_transistor_gate_bottom_drain_left"
+import _p_channel_d_mosfet_transistor_gate_bottom_drain_right from "./../symbols/p_channel_d_mosfet_transistor_gate_bottom_drain_right"
+import _p_channel_d_mosfet_transistor_gate_left_drain_bottom from "./../symbols/p_channel_d_mosfet_transistor_gate_left_drain_bottom"
+import _p_channel_d_mosfet_transistor_gate_left_drain_top from "./../symbols/p_channel_d_mosfet_transistor_gate_left_drain_top"
+import _p_channel_d_mosfet_transistor_gate_right_drain_bottom from "./../symbols/p_channel_d_mosfet_transistor_gate_right_drain_bottom"
+import _p_channel_d_mosfet_transistor_gate_right_drain_top from "./../symbols/p_channel_d_mosfet_transistor_gate_right_drain_top"
+import _p_channel_d_mosfet_transistor_gate_top_drain_left from "./../symbols/p_channel_d_mosfet_transistor_gate_top_drain_left"
+import _p_channel_d_mosfet_transistor_gate_top_drain_right from "./../symbols/p_channel_d_mosfet_transistor_gate_top_drain_right"
 import _p_channel_d_mosfet_transistor_horz from "./../symbols/p_channel_d_mosfet_transistor_horz"
 import _p_channel_d_mosfet_transistor_vert from "./../symbols/p_channel_d_mosfet_transistor_vert"
+import _p_channel_e_mosfet_transistor_gate_bottom_drain_left from "./../symbols/p_channel_e_mosfet_transistor_gate_bottom_drain_left"
+import _p_channel_e_mosfet_transistor_gate_bottom_drain_right from "./../symbols/p_channel_e_mosfet_transistor_gate_bottom_drain_right"
+import _p_channel_e_mosfet_transistor_gate_left_drain_bottom from "./../symbols/p_channel_e_mosfet_transistor_gate_left_drain_bottom"
+import _p_channel_e_mosfet_transistor_gate_left_drain_top from "./../symbols/p_channel_e_mosfet_transistor_gate_left_drain_top"
+import _p_channel_e_mosfet_transistor_gate_right_drain_bottom from "./../symbols/p_channel_e_mosfet_transistor_gate_right_drain_bottom"
+import _p_channel_e_mosfet_transistor_gate_right_drain_top from "./../symbols/p_channel_e_mosfet_transistor_gate_right_drain_top"
+import _p_channel_e_mosfet_transistor_gate_top_drain_left from "./../symbols/p_channel_e_mosfet_transistor_gate_top_drain_left"
+import _p_channel_e_mosfet_transistor_gate_top_drain_right from "./../symbols/p_channel_e_mosfet_transistor_gate_top_drain_right"
 import _p_channel_e_mosfet_transistor_horz from "./../symbols/p_channel_e_mosfet_transistor_horz"
 import _p_channel_e_mosfet_transistor_vert from "./../symbols/p_channel_e_mosfet_transistor_vert"
 import _photodiode_horz from "./../symbols/photodiode_horz"
@@ -467,8 +499,24 @@ export default {
   "mosfet_depletion_normally_on_vert": _mosfet_depletion_normally_on_vert,
   "mushroom_head_normally_open_momentary_horz": _mushroom_head_normally_open_momentary_horz,
   "mushroom_head_normally_open_momentary_vert": _mushroom_head_normally_open_momentary_vert,
+  "n_channel_d_mosfet_transistor_gate_bottom_drain_left": _n_channel_d_mosfet_transistor_gate_bottom_drain_left,
+  "n_channel_d_mosfet_transistor_gate_bottom_drain_right": _n_channel_d_mosfet_transistor_gate_bottom_drain_right,
+  "n_channel_d_mosfet_transistor_gate_left_drain_bottom": _n_channel_d_mosfet_transistor_gate_left_drain_bottom,
+  "n_channel_d_mosfet_transistor_gate_left_drain_top": _n_channel_d_mosfet_transistor_gate_left_drain_top,
+  "n_channel_d_mosfet_transistor_gate_right_drain_bottom": _n_channel_d_mosfet_transistor_gate_right_drain_bottom,
+  "n_channel_d_mosfet_transistor_gate_right_drain_top": _n_channel_d_mosfet_transistor_gate_right_drain_top,
+  "n_channel_d_mosfet_transistor_gate_top_drain_left": _n_channel_d_mosfet_transistor_gate_top_drain_left,
+  "n_channel_d_mosfet_transistor_gate_top_drain_right": _n_channel_d_mosfet_transistor_gate_top_drain_right,
   "n_channel_d_mosfet_transistor_horz": _n_channel_d_mosfet_transistor_horz,
   "n_channel_d_mosfet_transistor_vert": _n_channel_d_mosfet_transistor_vert,
+  "n_channel_e_mosfet_transistor_gate_bottom_drain_left": _n_channel_e_mosfet_transistor_gate_bottom_drain_left,
+  "n_channel_e_mosfet_transistor_gate_bottom_drain_right": _n_channel_e_mosfet_transistor_gate_bottom_drain_right,
+  "n_channel_e_mosfet_transistor_gate_left_drain_bottom": _n_channel_e_mosfet_transistor_gate_left_drain_bottom,
+  "n_channel_e_mosfet_transistor_gate_left_drain_top": _n_channel_e_mosfet_transistor_gate_left_drain_top,
+  "n_channel_e_mosfet_transistor_gate_right_drain_bottom": _n_channel_e_mosfet_transistor_gate_right_drain_bottom,
+  "n_channel_e_mosfet_transistor_gate_right_drain_top": _n_channel_e_mosfet_transistor_gate_right_drain_top,
+  "n_channel_e_mosfet_transistor_gate_top_drain_left": _n_channel_e_mosfet_transistor_gate_top_drain_left,
+  "n_channel_e_mosfet_transistor_gate_top_drain_right": _n_channel_e_mosfet_transistor_gate_top_drain_right,
   "n_channel_e_mosfet_transistor_horz": _n_channel_e_mosfet_transistor_horz,
   "n_channel_e_mosfet_transistor_vert": _n_channel_e_mosfet_transistor_vert,
   "njfet_transistor_horz": _njfet_transistor_horz,
@@ -491,8 +539,24 @@ export default {
   "opamp_with_power_left": _opamp_with_power_left,
   "opamp_with_power_right": _opamp_with_power_right,
   "opamp_with_power_up": _opamp_with_power_up,
+  "p_channel_d_mosfet_transistor_gate_bottom_drain_left": _p_channel_d_mosfet_transistor_gate_bottom_drain_left,
+  "p_channel_d_mosfet_transistor_gate_bottom_drain_right": _p_channel_d_mosfet_transistor_gate_bottom_drain_right,
+  "p_channel_d_mosfet_transistor_gate_left_drain_bottom": _p_channel_d_mosfet_transistor_gate_left_drain_bottom,
+  "p_channel_d_mosfet_transistor_gate_left_drain_top": _p_channel_d_mosfet_transistor_gate_left_drain_top,
+  "p_channel_d_mosfet_transistor_gate_right_drain_bottom": _p_channel_d_mosfet_transistor_gate_right_drain_bottom,
+  "p_channel_d_mosfet_transistor_gate_right_drain_top": _p_channel_d_mosfet_transistor_gate_right_drain_top,
+  "p_channel_d_mosfet_transistor_gate_top_drain_left": _p_channel_d_mosfet_transistor_gate_top_drain_left,
+  "p_channel_d_mosfet_transistor_gate_top_drain_right": _p_channel_d_mosfet_transistor_gate_top_drain_right,
   "p_channel_d_mosfet_transistor_horz": _p_channel_d_mosfet_transistor_horz,
   "p_channel_d_mosfet_transistor_vert": _p_channel_d_mosfet_transistor_vert,
+  "p_channel_e_mosfet_transistor_gate_bottom_drain_left": _p_channel_e_mosfet_transistor_gate_bottom_drain_left,
+  "p_channel_e_mosfet_transistor_gate_bottom_drain_right": _p_channel_e_mosfet_transistor_gate_bottom_drain_right,
+  "p_channel_e_mosfet_transistor_gate_left_drain_bottom": _p_channel_e_mosfet_transistor_gate_left_drain_bottom,
+  "p_channel_e_mosfet_transistor_gate_left_drain_top": _p_channel_e_mosfet_transistor_gate_left_drain_top,
+  "p_channel_e_mosfet_transistor_gate_right_drain_bottom": _p_channel_e_mosfet_transistor_gate_right_drain_bottom,
+  "p_channel_e_mosfet_transistor_gate_right_drain_top": _p_channel_e_mosfet_transistor_gate_right_drain_top,
+  "p_channel_e_mosfet_transistor_gate_top_drain_left": _p_channel_e_mosfet_transistor_gate_top_drain_left,
+  "p_channel_e_mosfet_transistor_gate_top_drain_right": _p_channel_e_mosfet_transistor_gate_top_drain_right,
   "p_channel_e_mosfet_transistor_horz": _p_channel_e_mosfet_transistor_horz,
   "p_channel_e_mosfet_transistor_vert": _p_channel_e_mosfet_transistor_vert,
   "photodiode_horz": _photodiode_horz,

--- a/scripts/generate-base-symbol-names.ts
+++ b/scripts/generate-base-symbol-names.ts
@@ -4,7 +4,9 @@ import { writeFileSync } from "node:fs"
 const baseSymbolNames = new Set<string>()
 
 for (const symbol of Object.keys(symbols)) {
-  const baseSymbolName = symbol.replace(/_(vert|horz|left|right|up|down)$/, "")
+  const baseSymbolName = symbol
+    .replace(/_gate_(left|right|top|bottom)_drain_(left|right|top|bottom)$/, "")
+    .replace(/_(vert|horz|left|right|up|down)$/, "")
   baseSymbolNames.add(baseSymbolName)
 }
 

--- a/symbols/n_channel_d_mosfet_transistor_gate_bottom_drain_left.ts
+++ b/symbols/n_channel_d_mosfet_transistor_gate_bottom_drain_left.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "bottom",
+  drainSide: "left",
+})

--- a/symbols/n_channel_d_mosfet_transistor_gate_bottom_drain_right.ts
+++ b/symbols/n_channel_d_mosfet_transistor_gate_bottom_drain_right.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "bottom",
+  drainSide: "right",
+})

--- a/symbols/n_channel_d_mosfet_transistor_gate_left_drain_bottom.ts
+++ b/symbols/n_channel_d_mosfet_transistor_gate_left_drain_bottom.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "left",
+  drainSide: "bottom",
+})

--- a/symbols/n_channel_d_mosfet_transistor_gate_left_drain_top.ts
+++ b/symbols/n_channel_d_mosfet_transistor_gate_left_drain_top.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "left",
+  drainSide: "top",
+})

--- a/symbols/n_channel_d_mosfet_transistor_gate_right_drain_bottom.ts
+++ b/symbols/n_channel_d_mosfet_transistor_gate_right_drain_bottom.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "right",
+  drainSide: "bottom",
+})

--- a/symbols/n_channel_d_mosfet_transistor_gate_right_drain_top.ts
+++ b/symbols/n_channel_d_mosfet_transistor_gate_right_drain_top.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "right",
+  drainSide: "top",
+})

--- a/symbols/n_channel_d_mosfet_transistor_gate_top_drain_left.ts
+++ b/symbols/n_channel_d_mosfet_transistor_gate_top_drain_left.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "top",
+  drainSide: "left",
+})

--- a/symbols/n_channel_d_mosfet_transistor_gate_top_drain_right.ts
+++ b/symbols/n_channel_d_mosfet_transistor_gate_top_drain_right.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "top",
+  drainSide: "right",
+})

--- a/symbols/n_channel_e_mosfet_transistor_gate_bottom_drain_left.ts
+++ b/symbols/n_channel_e_mosfet_transistor_gate_bottom_drain_left.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "bottom",
+  drainSide: "left",
+})

--- a/symbols/n_channel_e_mosfet_transistor_gate_bottom_drain_right.ts
+++ b/symbols/n_channel_e_mosfet_transistor_gate_bottom_drain_right.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "bottom",
+  drainSide: "right",
+})

--- a/symbols/n_channel_e_mosfet_transistor_gate_left_drain_bottom.ts
+++ b/symbols/n_channel_e_mosfet_transistor_gate_left_drain_bottom.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "left",
+  drainSide: "bottom",
+})

--- a/symbols/n_channel_e_mosfet_transistor_gate_left_drain_top.ts
+++ b/symbols/n_channel_e_mosfet_transistor_gate_left_drain_top.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "left",
+  drainSide: "top",
+})

--- a/symbols/n_channel_e_mosfet_transistor_gate_right_drain_bottom.ts
+++ b/symbols/n_channel_e_mosfet_transistor_gate_right_drain_bottom.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "right",
+  drainSide: "bottom",
+})

--- a/symbols/n_channel_e_mosfet_transistor_gate_right_drain_top.ts
+++ b/symbols/n_channel_e_mosfet_transistor_gate_right_drain_top.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "right",
+  drainSide: "top",
+})

--- a/symbols/n_channel_e_mosfet_transistor_gate_top_drain_left.ts
+++ b/symbols/n_channel_e_mosfet_transistor_gate_top_drain_left.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "top",
+  drainSide: "left",
+})

--- a/symbols/n_channel_e_mosfet_transistor_gate_top_drain_right.ts
+++ b/symbols/n_channel_e_mosfet_transistor_gate_top_drain_right.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./n_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./n_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "top",
+  drainSide: "right",
+})

--- a/symbols/p_channel_d_mosfet_transistor_gate_bottom_drain_left.ts
+++ b/symbols/p_channel_d_mosfet_transistor_gate_bottom_drain_left.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "bottom",
+  drainSide: "left",
+})

--- a/symbols/p_channel_d_mosfet_transistor_gate_bottom_drain_right.ts
+++ b/symbols/p_channel_d_mosfet_transistor_gate_bottom_drain_right.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "bottom",
+  drainSide: "right",
+})

--- a/symbols/p_channel_d_mosfet_transistor_gate_left_drain_bottom.ts
+++ b/symbols/p_channel_d_mosfet_transistor_gate_left_drain_bottom.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "left",
+  drainSide: "bottom",
+})

--- a/symbols/p_channel_d_mosfet_transistor_gate_left_drain_top.ts
+++ b/symbols/p_channel_d_mosfet_transistor_gate_left_drain_top.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "left",
+  drainSide: "top",
+})

--- a/symbols/p_channel_d_mosfet_transistor_gate_right_drain_bottom.ts
+++ b/symbols/p_channel_d_mosfet_transistor_gate_right_drain_bottom.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "right",
+  drainSide: "bottom",
+})

--- a/symbols/p_channel_d_mosfet_transistor_gate_right_drain_top.ts
+++ b/symbols/p_channel_d_mosfet_transistor_gate_right_drain_top.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "right",
+  drainSide: "top",
+})

--- a/symbols/p_channel_d_mosfet_transistor_gate_top_drain_left.ts
+++ b/symbols/p_channel_d_mosfet_transistor_gate_top_drain_left.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "top",
+  drainSide: "left",
+})

--- a/symbols/p_channel_d_mosfet_transistor_gate_top_drain_right.ts
+++ b/symbols/p_channel_d_mosfet_transistor_gate_top_drain_right.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_d_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_d_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "top",
+  drainSide: "right",
+})

--- a/symbols/p_channel_e_mosfet_transistor_gate_bottom_drain_left.ts
+++ b/symbols/p_channel_e_mosfet_transistor_gate_bottom_drain_left.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "bottom",
+  drainSide: "left",
+})

--- a/symbols/p_channel_e_mosfet_transistor_gate_bottom_drain_right.ts
+++ b/symbols/p_channel_e_mosfet_transistor_gate_bottom_drain_right.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "bottom",
+  drainSide: "right",
+})

--- a/symbols/p_channel_e_mosfet_transistor_gate_left_drain_bottom.ts
+++ b/symbols/p_channel_e_mosfet_transistor_gate_left_drain_bottom.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "left",
+  drainSide: "bottom",
+})

--- a/symbols/p_channel_e_mosfet_transistor_gate_left_drain_top.ts
+++ b/symbols/p_channel_e_mosfet_transistor_gate_left_drain_top.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "left",
+  drainSide: "top",
+})

--- a/symbols/p_channel_e_mosfet_transistor_gate_right_drain_bottom.ts
+++ b/symbols/p_channel_e_mosfet_transistor_gate_right_drain_bottom.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "right",
+  drainSide: "bottom",
+})

--- a/symbols/p_channel_e_mosfet_transistor_gate_right_drain_top.ts
+++ b/symbols/p_channel_e_mosfet_transistor_gate_right_drain_top.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "right",
+  drainSide: "top",
+})

--- a/symbols/p_channel_e_mosfet_transistor_gate_top_drain_left.ts
+++ b/symbols/p_channel_e_mosfet_transistor_gate_top_drain_left.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "top",
+  drainSide: "left",
+})

--- a/symbols/p_channel_e_mosfet_transistor_gate_top_drain_right.ts
+++ b/symbols/p_channel_e_mosfet_transistor_gate_top_drain_right.ts
@@ -1,0 +1,10 @@
+import { createMosfetSymbolVariant } from "drawing/createMosfetSymbolVariant"
+import horizontalSymbol from "./p_channel_e_mosfet_transistor_horz"
+import verticalSymbol from "./p_channel_e_mosfet_transistor_vert"
+
+export default createMosfetSymbolVariant({
+  horizontalSymbol,
+  verticalSymbol,
+  gateSide: "top",
+  drainSide: "right",
+})

--- a/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_bottom_drain_left.snap.svg
+++ b/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_bottom_drain_left.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M0.10000000000000003,0.42 L0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.19,-0.08999999999999998 L0.18,-0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,-0.29999999999999993 L-0.11000000000000001,-0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,-0.31000000000000005 L0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,-0.09 L-0.11000000000000001,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,-0.09 L0.09999999999999999,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.03999999999999999,-0.27 L-0.030000000000000016,-0.27 L-1.2246467991473533e-17,-0.2 L0.03999999999999999,-0.27" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-5.5109105961630896e-18,-0.09 L0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.17,-0.04999999999999999 L0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-9.797174393178826e-18" cy="-0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.5750000000000001" y1="-0.32499999999999996" x2="-0.525" y2="-0.2749999999999999" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="-0.2749999999999999" x2="-0.525" y2="-0.32499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="-0.20999999999999994"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.525" y1="-0.3350000000000001" x2="0.5750000000000001" y2="-0.28500000000000003" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="-0.28500000000000003" x2="0.5750000000000001" y2="-0.3350000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="-0.22000000000000006"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.07500000000000004" y1="0.39499999999999996" x2="0.12500000000000003" y2="0.445" stroke="red" stroke-width="0.004" />
+    <line x1="0.07500000000000004" y1="0.445" x2="0.12500000000000003" y2="0.39499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.06000000000000003" y="0.51"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_bottom_drain_right.snap.svg
+++ b/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_bottom_drain_right.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M-0.10000000000000003,0.42 L-0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.19,-0.08999999999999998 L-0.18,-0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,-0.29999999999999993 L0.11000000000000001,-0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,-0.31000000000000005 L-0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,-0.09 L0.11000000000000001,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,-0.09 L-0.09999999999999999,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.03999999999999999,-0.27 L0.030000000000000016,-0.27 L1.2246467991473533e-17,-0.2 L-0.03999999999999999,-0.27" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M5.5109105961630896e-18,-0.09 L-0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.17,-0.04999999999999999 L-0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="9.797174393178826e-18" cy="-0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.525" y1="-0.32499999999999996" x2="0.5750000000000001" y2="-0.2749999999999999" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="-0.2749999999999999" x2="0.5750000000000001" y2="-0.32499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="-0.20999999999999994"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.5750000000000001" y1="-0.3350000000000001" x2="-0.525" y2="-0.28500000000000003" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="-0.28500000000000003" x2="-0.525" y2="-0.3350000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="-0.22000000000000006"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.12500000000000003" y1="0.39499999999999996" x2="-0.07500000000000004" y2="0.445" stroke="red" stroke-width="0.004" />
+    <line x1="-0.12500000000000003" y1="0.445" x2="-0.07500000000000004" y2="0.39499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.14000000000000004" y="0.51"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_left_drain_bottom.snap.svg
+++ b/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_left_drain_bottom.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,-0.1 L0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.19 L0.09,-0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3,0.55 L0.3,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.31,-0.55 L0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.11 L0.31,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.1 L0.31,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.27,-0.04 L0.27,0.03 L0.2,0 L0.27,-0.04" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0 L0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.05,0.17 L0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="0.36" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="0.3475" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="-0.42" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="-0.4325" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.27499999999999997" y1="0.525" x2="0.325" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.27499999999999997" y1="0.5750000000000001" x2="0.325" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.26" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.285" y1="-0.5750000000000001" x2="0.335" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="0.285" y1="-0.525" x2="0.335" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.27" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.445" y1="-0.125" x2="-0.39499999999999996" y2="-0.07500000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.445" y1="-0.07500000000000001" x2="-0.39499999999999996" y2="-0.125" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.45999999999999996" y="-0.010000000000000002"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_left_drain_top.snap.svg
+++ b/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_left_drain_top.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.19 L0.09,0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3,-0.55 L0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.31,0.55 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.11 L0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.1 L0.31,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.27,0.04 L0.27,-0.03 L0.2,0 L0.27,0.04" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.05,-0.17 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="-0.36" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="-0.3725" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="0.42" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="0.4075" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.27499999999999997" y1="-0.5750000000000001" x2="0.325" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="0.27499999999999997" y1="-0.525" x2="0.325" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.26" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.285" y1="0.525" x2="0.335" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.285" y1="0.5750000000000001" x2="0.335" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.27" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.445" y1="0.07500000000000001" x2="-0.39499999999999996" y2="0.125" stroke="red" stroke-width="0.004" />
+    <line x1="-0.445" y1="0.125" x2="-0.39499999999999996" y2="0.07500000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.45999999999999996" y="0.19000000000000003"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_right_drain_bottom.snap.svg
+++ b/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_right_drain_bottom.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.42,-0.1 L-0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.19 L-0.09,-0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3,0.55 L-0.3,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.31,-0.55 L-0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.11 L-0.31,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.1 L-0.31,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.27,-0.04 L-0.27,0.03 L-0.2,0 L-0.27,-0.04" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0 L-0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.05,0.17 L-0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="0.36" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="0.3475" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="-0.42" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="-0.4325" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.325" y1="0.525" x2="-0.27499999999999997" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.325" y1="0.5750000000000001" x2="-0.27499999999999997" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.33999999999999997" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.335" y1="-0.5750000000000001" x2="-0.285" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="-0.335" y1="-0.525" x2="-0.285" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.35" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.39499999999999996" y1="-0.125" x2="0.445" y2="-0.07500000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.39499999999999996" y1="-0.07500000000000001" x2="0.445" y2="-0.125" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.38" y="-0.010000000000000002"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_right_drain_top.snap.svg
+++ b/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_right_drain_top.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.42,0.1 L-0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.19 L-0.09,0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3,-0.55 L-0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.31,0.55 L-0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.11 L-0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.1 L-0.31,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.27,0.04 L-0.27,-0.03 L-0.2,0 L-0.27,0.04" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0 L-0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.05,-0.17 L-0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="-0.36" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="-0.3725" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="0.42" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="0.4075" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.325" y1="-0.5750000000000001" x2="-0.27499999999999997" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="-0.325" y1="-0.525" x2="-0.27499999999999997" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.33999999999999997" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.335" y1="0.525" x2="-0.285" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.335" y1="0.5750000000000001" x2="-0.285" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.35" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.39499999999999996" y1="0.07500000000000001" x2="0.445" y2="0.125" stroke="red" stroke-width="0.004" />
+    <line x1="0.39499999999999996" y1="0.125" x2="0.445" y2="0.07500000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.38" y="0.19000000000000003"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_top_drain_left.snap.svg
+++ b/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_top_drain_left.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M0.10000000000000003,-0.42 L0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.19,0.08999999999999998 L0.18,0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,0.29999999999999993 L-0.11000000000000001,0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,0.31000000000000005 L0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,0.09 L-0.11000000000000001,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,0.09 L0.09999999999999999,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.03999999999999999,0.27 L-0.030000000000000016,0.27 L-1.2246467991473533e-17,0.2 L0.03999999999999999,0.27" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-5.5109105961630896e-18,0.09 L0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.17,0.04999999999999999 L0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-9.797174393178826e-18" cy="0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.5750000000000001" y1="0.2749999999999999" x2="-0.525" y2="0.32499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="0.32499999999999996" x2="-0.525" y2="0.2749999999999999" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="0.3899999999999999"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.525" y1="0.28500000000000003" x2="0.5750000000000001" y2="0.3350000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="0.3350000000000001" x2="0.5750000000000001" y2="0.28500000000000003" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="0.4"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.07500000000000004" y1="-0.445" x2="0.12500000000000003" y2="-0.39499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="0.07500000000000004" y1="-0.39499999999999996" x2="0.12500000000000003" y2="-0.445" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.06000000000000003" y="-0.33"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_top_drain_right.snap.svg
+++ b/tests/__snapshots__/n_channel_d_mosfet_transistor_gate_top_drain_right.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M-0.10000000000000003,-0.42 L-0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.19,0.08999999999999998 L-0.18,0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,0.29999999999999993 L0.11000000000000001,0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,0.31000000000000005 L-0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,0.09 L0.11000000000000001,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,0.09 L-0.09999999999999999,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.03999999999999999,0.27 L0.030000000000000016,0.27 L1.2246467991473533e-17,0.2 L-0.03999999999999999,0.27" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M5.5109105961630896e-18,0.09 L-0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.17,0.04999999999999999 L-0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="9.797174393178826e-18" cy="0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.525" y1="0.2749999999999999" x2="0.5750000000000001" y2="0.32499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="0.32499999999999996" x2="0.5750000000000001" y2="0.2749999999999999" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="0.3899999999999999"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.5750000000000001" y1="0.28500000000000003" x2="-0.525" y2="0.3350000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="0.3350000000000001" x2="-0.525" y2="0.28500000000000003" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="0.4"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.12500000000000003" y1="-0.445" x2="-0.07500000000000004" y2="-0.39499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="-0.12500000000000003" y1="-0.39499999999999996" x2="-0.07500000000000004" y2="-0.445" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.14000000000000004" y="-0.33"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_bottom_drain_left.snap.svg
+++ b/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_bottom_drain_left.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M0.10000000000000003,0.42 L0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,-0.29999999999999993 L-0.11000000000000001,-0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,-0.31000000000000005 L0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,-0.09 L-0.11000000000000001,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.15,-0.08999999999999998 L-0.07,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,-0.09 L0.09999999999999999,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.08,-0.09 L0.15,-0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.030000000000000006,-0.09 L0.039999999999999994,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.03999999999999999,-0.27 L-0.030000000000000016,-0.27 L-1.2246467991473533e-17,-0.2 L0.03999999999999999,-0.27" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-5.5109105961630896e-18,-0.09 L0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,-0.049999999999999996 L0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-9.797174393178826e-18" cy="-0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.5750000000000001" y1="-0.32499999999999996" x2="-0.525" y2="-0.2749999999999999" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="-0.2749999999999999" x2="-0.525" y2="-0.32499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="-0.20999999999999994"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.525" y1="-0.3350000000000001" x2="0.5750000000000001" y2="-0.28500000000000003" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="-0.28500000000000003" x2="0.5750000000000001" y2="-0.3350000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="-0.22000000000000006"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.07500000000000004" y1="0.39499999999999996" x2="0.12500000000000003" y2="0.445" stroke="red" stroke-width="0.004" />
+    <line x1="0.07500000000000004" y1="0.445" x2="0.12500000000000003" y2="0.39499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.06000000000000003" y="0.51"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_bottom_drain_right.snap.svg
+++ b/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_bottom_drain_right.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M-0.10000000000000003,0.42 L-0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,-0.29999999999999993 L0.11000000000000001,-0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,-0.31000000000000005 L-0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,-0.09 L0.11000000000000001,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.15,-0.08999999999999998 L0.07,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,-0.09 L-0.09999999999999999,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.08,-0.09 L-0.15,-0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.030000000000000006,-0.09 L-0.039999999999999994,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.03999999999999999,-0.27 L0.030000000000000016,-0.27 L1.2246467991473533e-17,-0.2 L-0.03999999999999999,-0.27" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M5.5109105961630896e-18,-0.09 L-0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,-0.049999999999999996 L-0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="9.797174393178826e-18" cy="-0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.525" y1="-0.32499999999999996" x2="0.5750000000000001" y2="-0.2749999999999999" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="-0.2749999999999999" x2="0.5750000000000001" y2="-0.32499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="-0.20999999999999994"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.5750000000000001" y1="-0.3350000000000001" x2="-0.525" y2="-0.28500000000000003" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="-0.28500000000000003" x2="-0.525" y2="-0.3350000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="-0.22000000000000006"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.12500000000000003" y1="0.39499999999999996" x2="-0.07500000000000004" y2="0.445" stroke="red" stroke-width="0.004" />
+    <line x1="-0.12500000000000003" y1="0.445" x2="-0.07500000000000004" y2="0.39499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.14000000000000004" y="0.51"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_left_drain_bottom.snap.svg
+++ b/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_left_drain_bottom.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,-0.1 L0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3,0.55 L0.3,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.31,-0.55 L0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.11 L0.31,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.15 L0.09,0.07" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.1 L0.31,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.08 L0.09,-0.15" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.03 L0.09,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.27,-0.04 L0.27,0.03 L0.2,0 L0.27,-0.04" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0 L0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.05,0.11 L0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="0.36" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="0.3475" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="-0.42" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="-0.4325" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.27499999999999997" y1="0.525" x2="0.325" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.27499999999999997" y1="0.5750000000000001" x2="0.325" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.26" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.285" y1="-0.5750000000000001" x2="0.335" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="0.285" y1="-0.525" x2="0.335" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.27" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.445" y1="-0.125" x2="-0.39499999999999996" y2="-0.07500000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.445" y1="-0.07500000000000001" x2="-0.39499999999999996" y2="-0.125" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.45999999999999996" y="-0.010000000000000002"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_left_drain_top.snap.svg
+++ b/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_left_drain_top.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3,-0.55 L0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.31,0.55 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.11 L0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.15 L0.09,-0.07" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.1 L0.31,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.08 L0.09,0.15" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.03 L0.09,0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.27,0.04 L0.27,-0.03 L0.2,0 L0.27,0.04" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.05,-0.11 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="-0.36" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="-0.3725" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="0.42" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="0.4075" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.27499999999999997" y1="-0.5750000000000001" x2="0.325" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="0.27499999999999997" y1="-0.525" x2="0.325" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.26" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.285" y1="0.525" x2="0.335" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.285" y1="0.5750000000000001" x2="0.335" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.27" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.445" y1="0.07500000000000001" x2="-0.39499999999999996" y2="0.125" stroke="red" stroke-width="0.004" />
+    <line x1="-0.445" y1="0.125" x2="-0.39499999999999996" y2="0.07500000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.45999999999999996" y="0.19000000000000003"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_right_drain_bottom.snap.svg
+++ b/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_right_drain_bottom.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.42,-0.1 L-0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3,0.55 L-0.3,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.31,-0.55 L-0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.11 L-0.31,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.15 L-0.09,0.07" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.1 L-0.31,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.08 L-0.09,-0.15" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.03 L-0.09,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.27,-0.04 L-0.27,0.03 L-0.2,0 L-0.27,-0.04" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0 L-0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.05,0.11 L-0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="0.36" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="0.3475" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="-0.42" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="-0.4325" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.325" y1="0.525" x2="-0.27499999999999997" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.325" y1="0.5750000000000001" x2="-0.27499999999999997" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.33999999999999997" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.335" y1="-0.5750000000000001" x2="-0.285" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="-0.335" y1="-0.525" x2="-0.285" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.35" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.39499999999999996" y1="-0.125" x2="0.445" y2="-0.07500000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.39499999999999996" y1="-0.07500000000000001" x2="0.445" y2="-0.125" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.38" y="-0.010000000000000002"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_right_drain_top.snap.svg
+++ b/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_right_drain_top.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.42,0.1 L-0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3,-0.55 L-0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.31,0.55 L-0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.11 L-0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.15 L-0.09,-0.07" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.1 L-0.31,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.08 L-0.09,0.15" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.03 L-0.09,0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.27,0.04 L-0.27,-0.03 L-0.2,0 L-0.27,0.04" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0 L-0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.05,-0.11 L-0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="-0.36" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="-0.3725" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="0.42" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="0.4075" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.325" y1="-0.5750000000000001" x2="-0.27499999999999997" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="-0.325" y1="-0.525" x2="-0.27499999999999997" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.33999999999999997" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.335" y1="0.525" x2="-0.285" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.335" y1="0.5750000000000001" x2="-0.285" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.35" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.39499999999999996" y1="0.07500000000000001" x2="0.445" y2="0.125" stroke="red" stroke-width="0.004" />
+    <line x1="0.39499999999999996" y1="0.125" x2="0.445" y2="0.07500000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.38" y="0.19000000000000003"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_top_drain_left.snap.svg
+++ b/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_top_drain_left.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M0.10000000000000003,-0.42 L0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,0.29999999999999993 L-0.11000000000000001,0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,0.31000000000000005 L0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,0.09 L-0.11000000000000001,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.15,0.08999999999999998 L-0.07,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,0.09 L0.09999999999999999,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.08,0.09 L0.15,0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.030000000000000006,0.09 L0.039999999999999994,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.03999999999999999,0.27 L-0.030000000000000016,0.27 L-1.2246467991473533e-17,0.2 L0.03999999999999999,0.27" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-5.5109105961630896e-18,0.09 L0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,0.049999999999999996 L0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-9.797174393178826e-18" cy="0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.5750000000000001" y1="0.2749999999999999" x2="-0.525" y2="0.32499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="0.32499999999999996" x2="-0.525" y2="0.2749999999999999" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="0.3899999999999999"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.525" y1="0.28500000000000003" x2="0.5750000000000001" y2="0.3350000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="0.3350000000000001" x2="0.5750000000000001" y2="0.28500000000000003" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="0.4"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.07500000000000004" y1="-0.445" x2="0.12500000000000003" y2="-0.39499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="0.07500000000000004" y1="-0.39499999999999996" x2="0.12500000000000003" y2="-0.445" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.06000000000000003" y="-0.33"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_top_drain_right.snap.svg
+++ b/tests/__snapshots__/n_channel_e_mosfet_transistor_gate_top_drain_right.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M-0.10000000000000003,-0.42 L-0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,0.29999999999999993 L0.11000000000000001,0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,0.31000000000000005 L-0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,0.09 L0.11000000000000001,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.15,0.08999999999999998 L0.07,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,0.09 L-0.09999999999999999,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.08,0.09 L-0.15,0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.030000000000000006,0.09 L-0.039999999999999994,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.03999999999999999,0.27 L0.030000000000000016,0.27 L1.2246467991473533e-17,0.2 L-0.03999999999999999,0.27" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M5.5109105961630896e-18,0.09 L-0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,0.049999999999999996 L-0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="9.797174393178826e-18" cy="0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.525" y1="0.2749999999999999" x2="0.5750000000000001" y2="0.32499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="0.32499999999999996" x2="0.5750000000000001" y2="0.2749999999999999" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="0.3899999999999999"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.5750000000000001" y1="0.28500000000000003" x2="-0.525" y2="0.3350000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="0.3350000000000001" x2="-0.525" y2="0.28500000000000003" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="0.4"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.12500000000000003" y1="-0.445" x2="-0.07500000000000004" y2="-0.39499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="-0.12500000000000003" y1="-0.39499999999999996" x2="-0.07500000000000004" y2="-0.445" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.14000000000000004" y="-0.33"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_bottom_drain_left.snap.svg
+++ b/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_bottom_drain_left.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M0.10000000000000003,0.42 L0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.19,-0.08999999999999998 L0.18,-0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,-0.29999999999999993 L-0.11000000000000001,-0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,-0.31000000000000005 L0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,-0.09 L-0.11000000000000001,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,-0.09 L0.09999999999999999,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.030000000000000013,-0.2 L0.03999999999999999,-0.2 L0.009999999999999983,-0.27 L-0.030000000000000013,-0.2" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-5.5109105961630896e-18,-0.09 L0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.17,-0.04999999999999999 L0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-9.797174393178826e-18" cy="-0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.5750000000000001" y1="-0.32499999999999996" x2="-0.525" y2="-0.2749999999999999" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="-0.2749999999999999" x2="-0.525" y2="-0.32499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="-0.20999999999999994"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.525" y1="-0.3350000000000001" x2="0.5750000000000001" y2="-0.28500000000000003" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="-0.28500000000000003" x2="0.5750000000000001" y2="-0.3350000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="-0.22000000000000006"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.07500000000000004" y1="0.39499999999999996" x2="0.12500000000000003" y2="0.445" stroke="red" stroke-width="0.004" />
+    <line x1="0.07500000000000004" y1="0.445" x2="0.12500000000000003" y2="0.39499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.06000000000000003" y="0.51"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_bottom_drain_right.snap.svg
+++ b/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_bottom_drain_right.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M-0.10000000000000003,0.42 L-0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.19,-0.08999999999999998 L-0.18,-0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,-0.29999999999999993 L0.11000000000000001,-0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,-0.31000000000000005 L-0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,-0.09 L0.11000000000000001,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,-0.09 L-0.09999999999999999,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.030000000000000013,-0.2 L-0.03999999999999999,-0.2 L-0.009999999999999983,-0.27 L0.030000000000000013,-0.2" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M5.5109105961630896e-18,-0.09 L-0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.17,-0.04999999999999999 L-0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="9.797174393178826e-18" cy="-0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.525" y1="-0.32499999999999996" x2="0.5750000000000001" y2="-0.2749999999999999" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="-0.2749999999999999" x2="0.5750000000000001" y2="-0.32499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="-0.20999999999999994"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.5750000000000001" y1="-0.3350000000000001" x2="-0.525" y2="-0.28500000000000003" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="-0.28500000000000003" x2="-0.525" y2="-0.3350000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="-0.22000000000000006"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.12500000000000003" y1="0.39499999999999996" x2="-0.07500000000000004" y2="0.445" stroke="red" stroke-width="0.004" />
+    <line x1="-0.12500000000000003" y1="0.445" x2="-0.07500000000000004" y2="0.39499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.14000000000000004" y="0.51"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_left_drain_bottom.snap.svg
+++ b/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_left_drain_bottom.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,-0.1 L0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.19 L0.09,-0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3,0.55 L0.3,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.31,-0.55 L0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.11 L0.31,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.1 L0.31,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.2,0.03 L0.2,-0.04 L0.27,-0.01 L0.2,0.03" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0 L0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.05,0.17 L0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="0.36" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="0.3475" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="-0.42" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="-0.4325" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.27499999999999997" y1="0.525" x2="0.325" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.27499999999999997" y1="0.5750000000000001" x2="0.325" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.26" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.285" y1="-0.5750000000000001" x2="0.335" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="0.285" y1="-0.525" x2="0.335" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.27" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.445" y1="-0.125" x2="-0.39499999999999996" y2="-0.07500000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.445" y1="-0.07500000000000001" x2="-0.39499999999999996" y2="-0.125" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.45999999999999996" y="-0.010000000000000002"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_left_drain_top.snap.svg
+++ b/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_left_drain_top.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.19 L0.09,0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3,-0.55 L0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.31,0.55 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.11 L0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.1 L0.31,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.2,-0.03 L0.2,0.04 L0.27,0.01 L0.2,-0.03" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.05,-0.17 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="-0.36" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="-0.3725" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="0.42" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="0.4075" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.27499999999999997" y1="-0.5750000000000001" x2="0.325" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="0.27499999999999997" y1="-0.525" x2="0.325" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.26" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.285" y1="0.525" x2="0.335" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.285" y1="0.5750000000000001" x2="0.335" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.27" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.445" y1="0.07500000000000001" x2="-0.39499999999999996" y2="0.125" stroke="red" stroke-width="0.004" />
+    <line x1="-0.445" y1="0.125" x2="-0.39499999999999996" y2="0.07500000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.45999999999999996" y="0.19000000000000003"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_right_drain_bottom.snap.svg
+++ b/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_right_drain_bottom.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.42,-0.1 L-0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.19 L-0.09,-0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3,0.55 L-0.3,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.31,-0.55 L-0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.11 L-0.31,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.1 L-0.31,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.2,0.03 L-0.2,-0.04 L-0.27,-0.01 L-0.2,0.03" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0 L-0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.05,0.17 L-0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="0.36" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="0.3475" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="-0.42" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="-0.4325" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.325" y1="0.525" x2="-0.27499999999999997" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.325" y1="0.5750000000000001" x2="-0.27499999999999997" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.33999999999999997" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.335" y1="-0.5750000000000001" x2="-0.285" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="-0.335" y1="-0.525" x2="-0.285" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.35" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.39499999999999996" y1="-0.125" x2="0.445" y2="-0.07500000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.39499999999999996" y1="-0.07500000000000001" x2="0.445" y2="-0.125" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.38" y="-0.010000000000000002"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_right_drain_top.snap.svg
+++ b/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_right_drain_top.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.42,0.1 L-0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.19 L-0.09,0.18" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3,-0.55 L-0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.31,0.55 L-0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.11 L-0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.1 L-0.31,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.2,-0.03 L-0.2,0.04 L-0.27,0.01 L-0.2,-0.03" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0 L-0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.05,-0.17 L-0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="-0.36" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="-0.3725" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="0.42" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="0.4075" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.325" y1="-0.5750000000000001" x2="-0.27499999999999997" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="-0.325" y1="-0.525" x2="-0.27499999999999997" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.33999999999999997" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.335" y1="0.525" x2="-0.285" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.335" y1="0.5750000000000001" x2="-0.285" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.35" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.39499999999999996" y1="0.07500000000000001" x2="0.445" y2="0.125" stroke="red" stroke-width="0.004" />
+    <line x1="0.39499999999999996" y1="0.125" x2="0.445" y2="0.07500000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.38" y="0.19000000000000003"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_top_drain_left.snap.svg
+++ b/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_top_drain_left.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M0.10000000000000003,-0.42 L0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.19,0.08999999999999998 L0.18,0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,0.29999999999999993 L-0.11000000000000001,0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,0.31000000000000005 L0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,0.09 L-0.11000000000000001,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,0.09 L0.09999999999999999,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.030000000000000013,0.2 L0.03999999999999999,0.2 L0.009999999999999983,0.27 L-0.030000000000000013,0.2" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-5.5109105961630896e-18,0.09 L0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.17,0.04999999999999999 L0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-9.797174393178826e-18" cy="0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.5750000000000001" y1="0.2749999999999999" x2="-0.525" y2="0.32499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="0.32499999999999996" x2="-0.525" y2="0.2749999999999999" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="0.3899999999999999"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.525" y1="0.28500000000000003" x2="0.5750000000000001" y2="0.3350000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="0.3350000000000001" x2="0.5750000000000001" y2="0.28500000000000003" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="0.4"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.07500000000000004" y1="-0.445" x2="0.12500000000000003" y2="-0.39499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="0.07500000000000004" y1="-0.39499999999999996" x2="0.12500000000000003" y2="-0.445" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.06000000000000003" y="-0.33"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_top_drain_right.snap.svg
+++ b/tests/__snapshots__/p_channel_d_mosfet_transistor_gate_top_drain_right.snap.svg
@@ -1,0 +1,45 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M-0.10000000000000003,-0.42 L-0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.19,0.08999999999999998 L-0.18,0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,0.29999999999999993 L0.11000000000000001,0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,0.31000000000000005 L-0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,0.09 L0.11000000000000001,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,0.09 L-0.09999999999999999,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.030000000000000013,0.2 L-0.03999999999999999,0.2 L-0.009999999999999983,0.27 L0.030000000000000013,0.2" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M5.5109105961630896e-18,0.09 L-0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.17,0.04999999999999999 L-0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="9.797174393178826e-18" cy="0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.525" y1="0.2749999999999999" x2="0.5750000000000001" y2="0.32499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="0.32499999999999996" x2="0.5750000000000001" y2="0.2749999999999999" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="0.3899999999999999"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.5750000000000001" y1="0.28500000000000003" x2="-0.525" y2="0.3350000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="0.3350000000000001" x2="-0.525" y2="0.28500000000000003" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="0.4"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.12500000000000003" y1="-0.445" x2="-0.07500000000000004" y2="-0.39499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="-0.12500000000000003" y1="-0.39499999999999996" x2="-0.07500000000000004" y2="-0.445" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.14000000000000004" y="-0.33"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_bottom_drain_left.snap.svg
+++ b/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_bottom_drain_left.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M0.10000000000000003,0.42 L0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,-0.29999999999999993 L-0.11000000000000001,-0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,-0.31000000000000005 L0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,-0.09 L-0.11000000000000001,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.15,-0.08999999999999998 L-0.07,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,-0.09 L0.09999999999999999,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.08,-0.09 L0.15,-0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.030000000000000006,-0.09 L0.039999999999999994,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.030000000000000013,-0.2 L0.03999999999999999,-0.2 L0.009999999999999983,-0.27 L-0.030000000000000013,-0.2" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-5.5109105961630896e-18,-0.09 L0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,-0.049999999999999996 L0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-9.797174393178826e-18" cy="-0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.5750000000000001" y1="-0.32499999999999996" x2="-0.525" y2="-0.2749999999999999" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="-0.2749999999999999" x2="-0.525" y2="-0.32499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="-0.20999999999999994"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.525" y1="-0.3350000000000001" x2="0.5750000000000001" y2="-0.28500000000000003" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="-0.28500000000000003" x2="0.5750000000000001" y2="-0.3350000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="-0.22000000000000006"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.07500000000000004" y1="0.39499999999999996" x2="0.12500000000000003" y2="0.445" stroke="red" stroke-width="0.004" />
+    <line x1="0.07500000000000004" y1="0.445" x2="0.12500000000000003" y2="0.39499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.06000000000000003" y="0.51"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_bottom_drain_right.snap.svg
+++ b/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_bottom_drain_right.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M-0.10000000000000003,0.42 L-0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,-0.29999999999999993 L0.11000000000000001,-0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,-0.31000000000000005 L-0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,-0.09 L0.11000000000000001,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.15,-0.08999999999999998 L0.07,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,-0.09 L-0.09999999999999999,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.08,-0.09 L-0.15,-0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.030000000000000006,-0.09 L-0.039999999999999994,-0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.030000000000000013,-0.2 L-0.03999999999999999,-0.2 L-0.009999999999999983,-0.27 L0.030000000000000013,-0.2" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M5.5109105961630896e-18,-0.09 L-0.009999999999999981,-0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,-0.049999999999999996 L-0.11,-0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="9.797174393178826e-18" cy="-0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.525" y1="-0.32499999999999996" x2="0.5750000000000001" y2="-0.2749999999999999" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="-0.2749999999999999" x2="0.5750000000000001" y2="-0.32499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="-0.20999999999999994"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.5750000000000001" y1="-0.3350000000000001" x2="-0.525" y2="-0.28500000000000003" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="-0.28500000000000003" x2="-0.525" y2="-0.3350000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="-0.22000000000000006"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.12500000000000003" y1="0.39499999999999996" x2="-0.07500000000000004" y2="0.445" stroke="red" stroke-width="0.004" />
+    <line x1="-0.12500000000000003" y1="0.445" x2="-0.07500000000000004" y2="0.39499999999999996" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.14000000000000004" y="0.51"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_left_drain_bottom.snap.svg
+++ b/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_left_drain_bottom.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,-0.1 L0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3,0.55 L0.3,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.31,-0.55 L0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.11 L0.31,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.15 L0.09,0.07" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.1 L0.31,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.08 L0.09,-0.15" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.03 L0.09,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.2,0.03 L0.2,-0.04 L0.27,-0.01 L0.2,0.03" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0 L0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.05,0.11 L0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="0.36" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="0.3475" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="-0.42" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="-0.4325" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.27499999999999997" y1="0.525" x2="0.325" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.27499999999999997" y1="0.5750000000000001" x2="0.325" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.26" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.285" y1="-0.5750000000000001" x2="0.335" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="0.285" y1="-0.525" x2="0.335" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.27" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.445" y1="-0.125" x2="-0.39499999999999996" y2="-0.07500000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.445" y1="-0.07500000000000001" x2="-0.39499999999999996" y2="-0.125" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.45999999999999996" y="-0.010000000000000002"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_left_drain_top.snap.svg
+++ b/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_left_drain_top.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M-0.42,0.1 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3,-0.55 L0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.31,0.55 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.11 L0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.15 L0.09,-0.07" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.1 L0.31,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0.08 L0.09,0.15" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,-0.03 L0.09,0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.2,-0.03 L0.2,0.04 L0.27,0.01 L0.2,-0.03" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09,0 L0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.05,-0.11 L0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="-0.36" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="-0.3725" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="0.42" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="0.4075" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.27499999999999997" y1="-0.5750000000000001" x2="0.325" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="0.27499999999999997" y1="-0.525" x2="0.325" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.26" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.285" y1="0.525" x2="0.335" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.285" y1="0.5750000000000001" x2="0.335" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.27" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.445" y1="0.07500000000000001" x2="-0.39499999999999996" y2="0.125" stroke="red" stroke-width="0.004" />
+    <line x1="-0.445" y1="0.125" x2="-0.39499999999999996" y2="0.07500000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.45999999999999996" y="0.19000000000000003"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_right_drain_bottom.snap.svg
+++ b/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_right_drain_bottom.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.42,-0.1 L-0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3,0.55 L-0.3,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.31,-0.55 L-0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.11 L-0.31,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.15 L-0.09,0.07" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.1 L-0.31,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.08 L-0.09,-0.15" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.03 L-0.09,-0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.2,0.03 L-0.2,-0.04 L-0.27,-0.01 L-0.2,0.03" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0 L-0.31,-0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.05,0.11 L-0.05,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="0.36" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="0.3475" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="-0.42" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="-0.4325" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.325" y1="0.525" x2="-0.27499999999999997" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.325" y1="0.5750000000000001" x2="-0.27499999999999997" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.33999999999999997" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.335" y1="-0.5750000000000001" x2="-0.285" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="-0.335" y1="-0.525" x2="-0.285" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.35" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.39499999999999996" y1="-0.125" x2="0.445" y2="-0.07500000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.39499999999999996" y1="-0.07500000000000001" x2="0.445" y2="-0.125" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.38" y="-0.010000000000000002"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_right_drain_top.snap.svg
+++ b/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_right_drain_top.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.504 -0.66 1.008 1.32" xmlns="http://www.w3.org/2000/svg"><path d="M0.42,0.1 L-0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3,-0.55 L-0.3,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.31,0.55 L-0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.11 L-0.31,-0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.15 L-0.09,-0.07" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.1 L-0.31,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0.08 L-0.09,0.15" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,-0.03 L-0.09,0.04" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.2,-0.03 L-0.2,0.04 L-0.27,0.01 L-0.2,-0.03" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09,0 L-0.31,0.01" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.05,-0.11 L-0.05,0.11" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-0.16" cy="0" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0" y="-0.36" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.0125" y="-0.3725" width="0.025" height="0.025" fill="blue" />
+    <text x="0" y="0.42" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.0125" y="0.4075" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.325" y1="-0.5750000000000001" x2="-0.27499999999999997" y2="-0.525" stroke="red" stroke-width="0.004" />
+    <line x1="-0.325" y1="-0.525" x2="-0.27499999999999997" y2="-0.5750000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.33999999999999997" y="-0.46"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.335" y1="0.525" x2="-0.285" y2="0.5750000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.335" y1="0.5750000000000001" x2="-0.285" y2="0.525" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.35" y="0.6400000000000001"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.39499999999999996" y1="0.07500000000000001" x2="0.445" y2="0.125" stroke="red" stroke-width="0.004" />
+    <line x1="0.39499999999999996" y1="0.125" x2="0.445" y2="0.07500000000000001" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.38" y="0.19000000000000003"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.42" y="-0.55" style="font: 0.05px monospace; fill: #833;">0.84 x 1.10</text>
+<text x="-0.42" y="-0.6000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.42" y="-0.65" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.42" y="-0.7000000000000001" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_top_drain_left.snap.svg
+++ b/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_top_drain_left.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M0.10000000000000003,-0.42 L0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,0.29999999999999993 L-0.11000000000000001,0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,0.31000000000000005 L0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,0.09 L-0.11000000000000001,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.15,0.08999999999999998 L-0.07,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,0.09 L0.09999999999999999,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.08,0.09 L0.15,0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.030000000000000006,0.09 L0.039999999999999994,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.030000000000000013,0.2 L0.03999999999999999,0.2 L0.009999999999999983,0.27 L-0.030000000000000013,0.2" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-5.5109105961630896e-18,0.09 L0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.11,0.049999999999999996 L0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-9.797174393178826e-18" cy="0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="-0.5750000000000001" y1="0.2749999999999999" x2="-0.525" y2="0.32499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="0.32499999999999996" x2="-0.525" y2="0.2749999999999999" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="0.3899999999999999"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="0.525" y1="0.28500000000000003" x2="0.5750000000000001" y2="0.3350000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="0.3350000000000001" x2="0.5750000000000001" y2="0.28500000000000003" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="0.4"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="0.07500000000000004" y1="-0.445" x2="0.12500000000000003" y2="-0.39499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="0.07500000000000004" y1="-0.39499999999999996" x2="0.12500000000000003" y2="-0.445" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.06000000000000003" y="-0.33"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_top_drain_right.snap.svg
+++ b/tests/__snapshots__/p_channel_e_mosfet_transistor_gate_top_drain_right.snap.svg
@@ -1,0 +1,47 @@
+<svg width="150" height="150" viewBox="-0.66 -0.5219999999999999 1.32 1.0439999999999998" xmlns="http://www.w3.org/2000/svg"><path d="M-0.10000000000000003,-0.42 L-0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.55,0.29999999999999993 L0.11000000000000001,0.3" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.55,0.31000000000000005 L-0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,0.09 L0.11000000000000001,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.15,0.08999999999999998 L0.07,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,0.09 L-0.09999999999999999,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.08,0.09 L-0.15,0.09000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.030000000000000006,0.09 L-0.039999999999999994,0.09" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.030000000000000013,0.2 L-0.03999999999999999,0.2 L-0.009999999999999983,0.27 L0.030000000000000013,0.2" fill="black" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M5.5109105961630896e-18,0.09 L-0.009999999999999981,0.31" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.11,0.049999999999999996 L-0.11,0.05000000000000001" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="9.797174393178826e-18" cy="0.16" r="0.29" fill="none" stroke="black" stroke-width="0.02" />
+    <text x="0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.33749999999999997" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.35" y="0" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.3625" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+
+    
+    <line x1="0.525" y1="0.2749999999999999" x2="0.5750000000000001" y2="0.32499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="0.525" y1="0.32499999999999996" x2="0.5750000000000001" y2="0.2749999999999999" stroke="red" stroke-width="0.004" />
+  
+    <text x="0.51" y="0.3899999999999999"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    
+    <line x1="-0.5750000000000001" y1="0.28500000000000003" x2="-0.525" y2="0.3350000000000001" stroke="red" stroke-width="0.004" />
+    <line x1="-0.5750000000000001" y1="0.3350000000000001" x2="-0.525" y2="0.28500000000000003" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.5900000000000001" y="0.4"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    
+    <line x1="-0.12500000000000003" y1="-0.445" x2="-0.07500000000000004" y2="-0.39499999999999996" stroke="red" stroke-width="0.004" />
+    <line x1="-0.12500000000000003" y1="-0.39499999999999996" x2="-0.07500000000000004" y2="-0.445" stroke="red" stroke-width="0.004" />
+  
+    <text x="-0.14000000000000004" y="-0.33"
+      text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text>
+<text x="-0.55" y="-0.43499999999999994" style="font: 0.05px monospace; fill: #833;">1.10 x 0.87</text>
+<text x="-0.55" y="-0.48499999999999993" dy="-0.15" style="font: 0.05px monospace; fill: #833;">1 [drain]</text>
+<text x="-0.55" y="-0.5349999999999999" dy="-0.15" style="font: 0.05px monospace; fill: #833;">2 [source]</text>
+<text x="-0.55" y="-0.585" dy="-0.15" style="font: 0.05px monospace; fill: #833;">3 [gate]</text></svg>

--- a/tests/mosfet-orientations.test.ts
+++ b/tests/mosfet-orientations.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import symbols from "../generated/symbols-index"
+import type { SchSymbol } from "../drawing/types"
+
+type SymbolSide = "left" | "right" | "top" | "bottom"
+
+const getPortSide = (
+  symbol: SchSymbol,
+  portLabel: "gate" | "drain" | "source",
+): SymbolSide => {
+  const port = symbol.ports.find(({ labels }) => labels.includes(portLabel))!
+  const dx = port.x - symbol.center.x
+  const dy = port.y - symbol.center.y
+  if (Math.abs(dx) > Math.abs(dy)) return dx < 0 ? "left" : "right"
+  return dy < 0 ? "bottom" : "top"
+}
+
+test("MOSFET variants place gate, drain, and source on named sides", () => {
+  const families = [
+    "n_channel_d_mosfet_transistor",
+    "n_channel_e_mosfet_transistor",
+    "p_channel_d_mosfet_transistor",
+    "p_channel_e_mosfet_transistor",
+  ] as const
+  const orientations = [
+    ["left", "top", "bottom"],
+    ["left", "bottom", "top"],
+    ["right", "top", "bottom"],
+    ["right", "bottom", "top"],
+    ["top", "left", "right"],
+    ["top", "right", "left"],
+    ["bottom", "left", "right"],
+    ["bottom", "right", "left"],
+  ] as const
+
+  for (const family of families) {
+    for (const [gateSide, drainSide, sourceSide] of orientations) {
+      const symbolName = `${family}_gate_${gateSide}_drain_${drainSide}`
+      const symbol = symbols[symbolName as keyof typeof symbols]
+
+      expect(symbol, symbolName).toBeDefined()
+      expect(getPortSide(symbol, "gate"), symbolName).toBe(gateSide)
+      expect(getPortSide(symbol, "drain"), symbolName).toBe(drainSide)
+      expect(getPortSide(symbol, "source"), symbolName).toBe(sourceSide)
+    }
+  }
+})


### PR DESCRIPTION
## Summary

- add all eight valid gate/drain orientation variants for N-channel and P-channel enhancement and depletion MOSFET symbols
- name variants semantically as `<family>_gate_<side>_drain_<side>` so downstream circuit JSON can reference a normal `symbol_name`
- derive variants from the existing horizontal and vertical artwork using the shared symbol flip helpers
- keep semantic orientation variants grouped under the original MOSFET base names during type generation

The source terminal is always opposite the drain, so gate and drain uniquely identify each valid orientation.

## Validation

- `bun run build`
- `bun test` (10 tests, 504 assertions)
- `bun run snapshot:validate`
- `bun run format:check`
- `git diff --check`

Includes 32 SVG snapshots and a focused test that verifies gate, drain, and source placement for every variant.
