### PR TITLE
Tighten labels on compact vertical capacitors

### DIFF
--- a/drawing/createPassiveSizeVariant.ts
+++ b/drawing/createPassiveSizeVariant.ts
@@ -11,6 +11,8 @@ interface CreatePassiveSizeVariantOptions {
   pin2Labels?: string[]
 }
 
+const verticalCapacitorAnnotationX = 0.095
+
 const annotationLayouts: Record<
   PassiveKind,
   {
@@ -33,7 +35,7 @@ const annotationLayouts: Record<
   capacitor: {
     horizontalOffset: 0.24,
     horizontalHeight: 0.65,
-    verticalX: 0.2,
+    verticalX: verticalCapacitorAnnotationX,
     verticalRefY: 0.095,
     verticalValY: -0.095,
     verticalWidth: 0.9,

--- a/tests/__snapshots__/capacitor_sm_down.snap.svg
+++ b/tests/__snapshots__/capacitor_sm_down.snap.svg
@@ -2,8 +2,8 @@
     <path d="M0.16,-0.060000000000000005 L-0.16,-0.05999999999999999" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.16,0.05999999999999999 L-0.16,0.060000000000000005" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M3.673940397442059e-18,0.06 L1.5308084989341915e-17,0.25" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.2" y="-0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.1875" y="-0.1075" width="0.025" height="0.025" fill="blue" />
-    <text x="0.2" y="0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.1875" y="0.0825" width="0.025" height="0.025" fill="blue" />
+    <text x="0.095" y="-0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.0825" y="-0.1075" width="0.025" height="0.025" fill="blue" />
+    <text x="0.095" y="0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.0825" y="0.0825" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.025000000000000015" y1="-0.275" x2="0.024999999999999988" y2="-0.225" stroke="red" stroke-width="0.004" />

--- a/tests/__snapshots__/capacitor_sm_up.snap.svg
+++ b/tests/__snapshots__/capacitor_sm_up.snap.svg
@@ -2,8 +2,8 @@
     <path d="M-0.16,0.05999999999999999 L0.16,0.060000000000000005" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.16,-0.060000000000000005 L0.16,-0.05999999999999999" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M3.673940397442059e-18,-0.06 L1.5308084989341915e-17,-0.25" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.2" y="-0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.1875" y="-0.1075" width="0.025" height="0.025" fill="blue" />
-    <text x="0.2" y="0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.1875" y="0.0825" width="0.025" height="0.025" fill="blue" />
+    <text x="0.095" y="-0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.0825" y="-0.1075" width="0.025" height="0.025" fill="blue" />
+    <text x="0.095" y="0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.0825" y="0.0825" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.025000000000000015" y1="0.225" x2="0.024999999999999988" y2="0.275" stroke="red" stroke-width="0.004" />

--- a/tests/__snapshots__/capacitor_xs_down.snap.svg
+++ b/tests/__snapshots__/capacitor_xs_down.snap.svg
@@ -2,8 +2,8 @@
     <path d="M0.14,-0.05000000000000001 L-0.14,-0.049999999999999996" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.14,0.049999999999999996 L-0.14,0.05000000000000001" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M3.061616997868383e-18,0.05 L1.071565949253934e-17,0.175" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.2" y="-0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.1875" y="-0.1075" width="0.025" height="0.025" fill="blue" />
-    <text x="0.2" y="0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.1875" y="0.0825" width="0.025" height="0.025" fill="blue" />
+    <text x="0.095" y="-0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.0825" y="-0.1075" width="0.025" height="0.025" fill="blue" />
+    <text x="0.095" y="0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.0825" y="0.0825" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.025000000000000012" y1="-0.19999999999999998" x2="0.02499999999999999" y2="-0.15" stroke="red" stroke-width="0.004" />

--- a/tests/__snapshots__/capacitor_xs_up.snap.svg
+++ b/tests/__snapshots__/capacitor_xs_up.snap.svg
@@ -2,8 +2,8 @@
     <path d="M-0.14,0.049999999999999996 L0.14,0.05000000000000001" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.14,-0.05000000000000001 L0.14,-0.049999999999999996" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M3.061616997868383e-18,-0.05 L1.071565949253934e-17,-0.175" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.2" y="-0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.1875" y="-0.1075" width="0.025" height="0.025" fill="blue" />
-    <text x="0.2" y="0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.1875" y="0.0825" width="0.025" height="0.025" fill="blue" />
+    <text x="0.095" y="-0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.0825" y="-0.1075" width="0.025" height="0.025" fill="blue" />
+    <text x="0.095" y="0.095" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.0825" y="0.0825" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.025000000000000012" y1="0.15" x2="0.02499999999999999" y2="0.19999999999999998" stroke="red" stroke-width="0.004" />

--- a/tests/passive-size-variants.test.ts
+++ b/tests/passive-size-variants.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test"
-import type { PathPrimitive, Point, SchSymbol } from "../drawing/types"
+import type {
+  PathPrimitive,
+  Point,
+  SchSymbol,
+  TextPrimitive,
+} from "../drawing/types"
 import symbolIndex from "../generated/symbols-index"
 
 const symbols = symbolIndex as Record<string, SchSymbol>
@@ -34,6 +39,8 @@ const capacitorDimensions = {
   xs: { plateHeight: 0.28, gap: 0.1 },
 } as const
 
+const verticalCapacitorAnnotationX = 0.095
+
 interface Segment {
   start: Point
   end: Point
@@ -66,6 +73,20 @@ const getPaths = (symbol: SchSymbol): PathPrimitive[] =>
   symbol.primitives.filter(
     (primitive): primitive is PathPrimitive => primitive.type === "path",
   )
+
+const getAnnotation = (
+  symbol: SchSymbol,
+  text: "{REF}" | "{VAL}",
+): TextPrimitive => {
+  const annotation = symbol.primitives.find(
+    (primitive): primitive is TextPrimitive =>
+      primitive.type === "text" && primitive.text === text,
+  )
+
+  if (!annotation) throw new Error(`Missing annotation: ${text}`)
+
+  return annotation
+}
 
 const getSegments = (symbol: SchSymbol): Segment[] =>
   getPaths(symbol).flatMap((path) =>
@@ -198,6 +219,22 @@ test("compact capacitors preserve pin polarity aliases", () => {
       expect(getPort(symbol, "1").labels).not.toContain("neg")
       expect(getPort(symbol, "2").labels).toContain("neg")
       expect(getPort(symbol, "2").labels).not.toContain("pos")
+    }
+  }
+})
+
+test("vertical compact capacitor annotations stay inside the plate span", () => {
+  for (const size of sizeVariants) {
+    for (const orientation of ["up", "down"] as const) {
+      const symbol = getSymbol("capacitor", size, orientation)
+      const ref = getAnnotation(symbol, "{REF}")
+      const val = getAnnotation(symbol, "{VAL}")
+      const plateHalfWidth = capacitorDimensions[size].plateHeight / 2
+
+      expect(ref.x).toBe(verticalCapacitorAnnotationX)
+      expect(val.x).toBe(verticalCapacitorAnnotationX)
+      expect(ref.x).toBeLessThan(plateHalfWidth)
+      expect(val.x).toBeLessThan(plateHalfWidth)
     }
   }
 })


### PR DESCRIPTION
### Motivation
- Compact vertical capacitor labels should sit close to the symbol body.

### Before
- `REF` and `VAL` started at x = 0.2, outside the small and extra-small capacitor plate spans.

### After
- Both labels start at x = 0.095, inside the plate span for up and down variants, with numeric assertions and updated SVG snapshots.