### PR TITLE
keep vertical capacitor labels within terminal bounds

### DIFF
--- a/symbols/capacitor_down.ts
+++ b/symbols/capacitor_down.ts
@@ -26,11 +26,11 @@ const symbol = modifySymbol({
   size: { width: bounds.width, height: bounds.height },
   center: { x: bounds.centerX, y: bounds.centerY },
 })
-  .changeTextAnchor("{VAL}", "top_left")
   .rotateRightFacingSymbol("down")
   .labelPort("left1", ["1", "pos"])
   .labelPort("right1", ["2", "neg"])
-  .changeTextAnchor("{REF}", "bottom_left")
+  .changeTextAnchor("{REF}", "middle_left")
+  .changeTextAnchor("{VAL}", "middle_left")
   .build()
 
 export default {

--- a/symbols/capacitor_up.ts
+++ b/symbols/capacitor_up.ts
@@ -26,11 +26,11 @@ const symbol = modifySymbol({
   size: { width: bounds.width, height: bounds.height },
   center: { x: bounds.centerX, y: bounds.centerY },
 })
-  .changeTextAnchor("{VAL}", "top_left")
   .rotateRightFacingSymbol("up")
   .labelPort("left1", ["1", "pos"])
   .labelPort("right1", ["2", "neg"])
-  .changeTextAnchor("{REF}", "bottom_left")
+  .changeTextAnchor("{REF}", "middle_left")
+  .changeTextAnchor("{VAL}", "middle_left")
   .build()
 
 export default {

--- a/tests/__snapshots__/capacitor_down.snap.svg
+++ b/tests/__snapshots__/capacitor_down.snap.svg
@@ -2,8 +2,8 @@
     <path d="M-3.673940397442059e-18,-0.06 L-1.8369701987210297e-17,-0.3" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.16002,0.05999999999999999 L-0.16002,0.060000000000000005" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M0.16002,-0.060000000000000005 L-0.16002,-0.05999999999999999" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.11499999999999999" y="-0.2" dx="0" dy="0" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.1025" y="-0.21250000000000002" width="0.025" height="0.025" fill="blue" />
-    <text x="0.11500000000000002" y="0.2" dx="0" dy="0.1" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.10250000000000002" y="0.1875" width="0.025" height="0.025" fill="blue" />
+    <text x="0.11499999999999999" y="-0.2" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.1025" y="-0.21250000000000002" width="0.025" height="0.025" fill="blue" />
+    <text x="0.11500000000000002" y="0.2" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.10250000000000002" y="0.1875" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.02500000000000002" y1="-0.325" x2="0.024999999999999984" y2="-0.27499999999999997" stroke="red" stroke-width="0.004" />

--- a/tests/__snapshots__/capacitor_up.snap.svg
+++ b/tests/__snapshots__/capacitor_up.snap.svg
@@ -2,8 +2,8 @@
     <path d="M-3.673940397442059e-18,0.06 L-1.8369701987210297e-17,0.3" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.16002,-0.060000000000000005 L0.16002,-0.05999999999999999" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M-0.16002,0.05999999999999999 L0.16002,0.060000000000000005" fill="none" stroke="black" stroke-width="0.012" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.09500000000000001" y="-0.2" dx="0" dy="0" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.08250000000000002" y="-0.21250000000000002" width="0.025" height="0.025" fill="blue" />
-    <text x="0.09499999999999999" y="0.2" dx="0" dy="0.1" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.08249999999999999" y="0.1875" width="0.025" height="0.025" fill="blue" />
+    <text x="0.09500000000000001" y="-0.2" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.08250000000000002" y="-0.21250000000000002" width="0.025" height="0.025" fill="blue" />
+    <text x="0.09499999999999999" y="0.2" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.08249999999999999" y="0.1875" width="0.025" height="0.025" fill="blue" />
 
     
     <line x1="-0.02500000000000002" y1="0.27499999999999997" x2="0.024999999999999984" y2="0.325" stroke="red" stroke-width="0.004" />

--- a/tests/capacitor-vertical-text-bounds.test.ts
+++ b/tests/capacitor-vertical-text-bounds.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import type { SchSymbol, TextPrimitive } from "drawing/types"
+import capacitorDown from "symbols/capacitor_down"
+import capacitorUp from "symbols/capacitor_up"
+
+const REFERENCE_DESIGNATOR_HEIGHT_MM = 0.18
+
+const getTextBounds = ({
+  textPrimitive,
+}: {
+  textPrimitive: TextPrimitive
+}) => {
+  let minY = textPrimitive.y - REFERENCE_DESIGNATOR_HEIGHT_MM / 2
+  let maxY = textPrimitive.y + REFERENCE_DESIGNATOR_HEIGHT_MM / 2
+
+  if (textPrimitive.anchor.includes("top")) {
+    minY = textPrimitive.y - REFERENCE_DESIGNATOR_HEIGHT_MM
+    maxY = textPrimitive.y
+  } else if (textPrimitive.anchor.includes("bottom")) {
+    minY = textPrimitive.y
+    maxY = textPrimitive.y + REFERENCE_DESIGNATOR_HEIGHT_MM
+  }
+
+  return { minY, maxY }
+}
+
+const expectTextWithinVerticalPorts = (symbol: SchSymbol) => {
+  const minPortY = Math.min(...symbol.ports.map((port) => port.y))
+  const maxPortY = Math.max(...symbol.ports.map((port) => port.y))
+  const textPrimitives = symbol.primitives.filter(
+    (primitive) => primitive.type === "text",
+  )
+
+  expect(textPrimitives).toHaveLength(2)
+  for (const textPrimitive of textPrimitives) {
+    const textBounds = getTextBounds({ textPrimitive })
+    expect(textPrimitive.anchor).toBe("middle_left")
+    expect(textBounds.minY).toBeGreaterThanOrEqual(minPortY)
+    expect(textBounds.maxY).toBeLessThanOrEqual(maxPortY)
+  }
+}
+
+test("vertical capacitor labels stay within the port y bounds", () => {
+  expectTextWithinVerticalPorts(capacitorUp)
+  expectTextWithinVerticalPorts(capacitorDown)
+})


### PR DESCRIPTION
motivation : REF and VAL blocking solver to draw a straight line 